### PR TITLE
feat: expose TableProvider trait in Python

### DIFF
--- a/python/letsql/backends/datafusion/__init__.py
+++ b/python/letsql/backends/datafusion/__init__.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import letsql
 import letsql.internal as df
 import pyarrow as pa
 import pyarrow.dataset as ds
@@ -27,9 +28,8 @@ from ibis.expr.operations.udf import InputType
 from ibis.formats.pyarrow import PyArrowType
 from ibis.util import gen_name, normalize_filename
 
-from letsql.internal import SessionContext
-from letsql.internal import SessionConfig
-
+from letsql.backends.datafusion.provider import IbisTableProvider
+from letsql.internal import SessionContext, SessionConfig, TableProvider
 from letsql.backends.datafusion.compiler import DataFusionCompiler
 
 
@@ -45,7 +45,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
 
     @property
     def version(self):
-        return "0.1.2"
+        return letsql.__version__
 
     def do_connect(
         self, config: Mapping[str, str | Path] | SessionContext | None = None
@@ -358,7 +358,9 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
             source, "to_pyarrow_batches"
         ):
             self.con.deregister_table(table_name)
-            self.con.register_ibis_table(table_name, source)
+            self.con.register_table_provider(
+                table_name, TableProvider(IbisTableProvider(source))
+            )
             return self.table(table_name)
         elif isinstance(source, ibis.expr.types.Expr) and hasattr(
             source, "to_pyarrow_batches"

--- a/python/letsql/backends/datafusion/provider.py
+++ b/python/letsql/backends/datafusion/provider.py
@@ -1,0 +1,18 @@
+import ibis.expr.types as ir
+
+from letsql.internal import AbstractTableProvider
+
+
+class IbisTableProvider(AbstractTableProvider):
+    def __init__(self, table: ir.Table):
+        self.table = table
+
+    def schema(self):
+        return self.table.schema().to_pyarrow()
+
+    def scan(self, filters=None):
+        table = self.table
+        if filters:
+            table = self.table.filter(filters)
+
+        return table.to_pyarrow_batches()

--- a/python/letsql/backends/datafusion/tests/test_provider.py
+++ b/python/letsql/backends/datafusion/tests/test_provider.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import pytest
+
+import letsql as ls
+from letsql.backends.datafusion.provider import IbisTableProvider
+
+import pyarrow as pa
+
+
+@pytest.fixture(scope="session")
+def data_dir():
+    root = Path(__file__).absolute().parents[5]
+    data_dir = root / "ci" / "ibis-testing-data"
+    return data_dir
+
+
+@pytest.fixture(scope="session")
+def con(data_dir):
+    conn = ls.connect()
+    parquet_dir = data_dir / "parquet"
+    conn.register(parquet_dir / "functional_alltypes.parquet", "functional_alltypes")
+
+    return conn
+
+
+def test_table_provider_scan(con):
+    table_provider = IbisTableProvider(con.table("functional_alltypes"))
+    batches = table_provider.scan()
+
+    assert batches is not None
+    assert isinstance(batches, pa.RecordBatchReader)
+
+
+def test_table_provider_schema(con):
+    table_provider = IbisTableProvider(con.table("functional_alltypes"))
+    schema = table_provider.schema()
+    assert schema is not None
+    assert isinstance(schema, pa.Schema)

--- a/python/letsql/internal.py
+++ b/python/letsql/internal.py
@@ -14,6 +14,7 @@ from ._internal import (
     LogicalPlan,
     LogicalPlanBuilder,
     OptimizerRule,
+    TableProvider,
 )
 
 __all__ = [
@@ -29,6 +30,8 @@ __all__ = [
     "AggregateUDF",
     "OptimizerRule",
     "OptimizationRule",
+    "TableProvider",
+    "AbstractTableProvider",
 ]
 
 
@@ -53,6 +56,16 @@ class Accumulator(metaclass=ABCMeta):
 class OptimizationRule(metaclass=ABCMeta):
     @abstractmethod
     def try_optimize(self, plan: LogicalPlan) -> LogicalPlan:
+        pass
+
+
+class AbstractTableProvider(metaclass=ABCMeta):
+    @abstractmethod
+    def schema(self):
+        pass
+
+    @abstractmethod
+    def scan(self, filters=None):
         pass
 
 

--- a/src/ibis_filter_expression.rs
+++ b/src/ibis_filter_expression.rs
@@ -5,7 +5,6 @@ use pyo3::prelude::PyModule;
 use pyo3::{IntoPy, PyAny, PyObject, Python};
 
 use crate::errors::DataFusionError;
-use crate::pyarrow_filter_expression::PyArrowFilterExpression;
 
 #[derive(Debug, Clone)]
 #[repr(transparent)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod utils;
 mod ibis_filter_expression;
 mod ibis_table;
 mod ibis_table_exec;
+mod provider;
 mod record_batch;
 
 // Used to define Tokio Runtime as a Python module attribute
@@ -53,6 +54,7 @@ fn _internal(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<builder::PyLogicalPlanBuilder>()?;
     m.add_class::<optimizer::PyOptimizerContext>()?;
     m.add_class::<optimizer::PyOptimizerRule>()?;
+    m.add_class::<provider::PyTableProvider>()?;
 
     // Register `common` as a submodule. Matching `datafusion-common` https://docs.rs/datafusion-common/latest/datafusion_common/
     let common = PyModule::new(py, "common")?;
@@ -75,6 +77,10 @@ fn _internal(py: Python, m: &PyModule) -> PyResult<()> {
     let builder = PyModule::new(py, "builder")?;
     builder::init_module(builder)?;
     m.add_submodule(builder)?;
+
+    let provider = PyModule::new(py, "provider")?;
+    builder::init_module(provider)?;
+    m.add_submodule(provider)?;
 
     Ok(())
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -1,0 +1,101 @@
+use std::any::Any;
+use std::sync::Arc;
+
+use arrow::datatypes::SchemaRef;
+use arrow::pyarrow::PyArrowType;
+use async_trait::async_trait;
+use datafusion::datasource::TableProvider;
+use datafusion::execution::context::SessionState;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion_common::DataFusionError;
+use datafusion_expr::{Expr, TableProviderFilterPushDown, TableType};
+use pyo3::types::{IntoPyDict, PyTuple};
+use pyo3::{pyclass, pymethods, PyAny, PyObject, PyResult, Python};
+
+use crate::ibis_filter_expression::IbisFilterExpression;
+use crate::ibis_table_exec::IbisTableExec;
+
+#[pyclass(name = "TableProvider", module = "datafusion", subclass)]
+#[derive(Debug, Clone)]
+pub struct PyTableProvider {
+    table_provider: PyObject,
+}
+
+#[pymethods]
+impl PyTableProvider {
+    #[new]
+    #[pyo3(signature=(table_provider))]
+    pub fn new(table_provider: &PyAny) -> PyResult<Self> {
+        Ok(Self {
+            table_provider: table_provider.into(),
+        })
+    }
+}
+
+#[async_trait]
+impl TableProvider for PyTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Python::with_gil(|py| {
+            let table_provider = self.table_provider.as_ref(py);
+            Arc::new(
+                table_provider
+                    .call_method0("schema")
+                    .unwrap()
+                    .extract::<PyArrowType<_>>()
+                    .unwrap()
+                    .0,
+            )
+        })
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &SessionState,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
+        Python::with_gil(|py| {
+            let args = filters
+                .iter()
+                .map(|filter| {
+                    IbisFilterExpression::try_from(filter)
+                        .unwrap()
+                        .inner()
+                        .clone()
+                })
+                .collect::<Vec<PyObject>>();
+            let ibis_filters = PyTuple::new(py, &args);
+            let kwargs = [("filters", ibis_filters)].into_py_dict(py);
+
+            let table = self
+                .table_provider
+                .call_method(py, "scan", (), Some(kwargs))
+                .unwrap();
+
+            let plan: Arc<dyn ExecutionPlan> = Arc::new(
+                IbisTableExec::new(py, table.as_ref(py), projection)
+                    .map_err(|err| DataFusionError::External(Box::new(err)))?,
+            );
+            Ok(plan)
+        })
+    }
+
+    fn supports_filter_pushdown(
+        &self,
+        filter: &Expr,
+    ) -> datafusion_common::Result<TableProviderFilterPushDown> {
+        match IbisFilterExpression::try_from(filter) {
+            Ok(_) => Ok(TableProviderFilterPushDown::Exact),
+            _ => Ok(TableProviderFilterPushDown::Unsupported),
+        }
+    }
+}

--- a/src/py_record_batch_provider.rs
+++ b/src/py_record_batch_provider.rs
@@ -41,8 +41,6 @@ use datafusion_expr::Expr;
 
 use async_trait::async_trait;
 
-use futures::StreamExt;
-
 #[derive(Clone, Debug)]
 pub struct PyRecordBatchProvider {
     reader: Arc<Mutex<Option<ArrowArrayStreamReader>>>,

--- a/src/udaf.rs
+++ b/src/udaf.rs
@@ -24,16 +24,6 @@ impl RustAccumulator {
 }
 
 impl Accumulator for RustAccumulator {
-    fn state(&mut self) -> Result<Vec<ScalarValue>> {
-        Python::with_gil(|py| self.accum.as_ref(py).call_method0("state")?.extract())
-            .map_err(|e| DataFusionError::Execution(format!("{e}")))
-    }
-
-    fn evaluate(&mut self) -> Result<ScalarValue> {
-        Python::with_gil(|py| self.accum.as_ref(py).call_method0("evaluate")?.extract())
-            .map_err(|e| DataFusionError::Execution(format!("{e}")))
-    }
-
     fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
         Python::with_gil(|py| {
             // 1. cast args to Pyarrow array
@@ -51,6 +41,20 @@ impl Accumulator for RustAccumulator {
 
             Ok(())
         })
+    }
+
+    fn evaluate(&mut self) -> Result<ScalarValue> {
+        Python::with_gil(|py| self.accum.as_ref(py).call_method0("evaluate")?.extract())
+            .map_err(|e| DataFusionError::Execution(format!("{e}")))
+    }
+
+    fn size(&self) -> usize {
+        std::mem::size_of_val(self)
+    }
+
+    fn state(&mut self) -> Result<Vec<ScalarValue>> {
+        Python::with_gil(|py| self.accum.as_ref(py).call_method0("state")?.extract())
+            .map_err(|e| DataFusionError::Execution(format!("{e}")))
     }
 
     fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
@@ -71,10 +75,6 @@ impl Accumulator for RustAccumulator {
 
             Ok(())
         })
-    }
-
-    fn size(&self) -> usize {
-        std::mem::size_of_val(self)
     }
 
     fn retract_batch(&mut self, values: &[ArrayRef]) -> Result<()> {


### PR DESCRIPTION
The objective is to be able to debug the code, and make it easy to extend.

The debug-ability of the code was tested manually via pdb with `breakpoint()`.

Additionally this PR does some refactoring.

The `register_ibis_table` will deprecated in the future.

closes #25