### PR TITLE
feat: drop connection handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![PyPI - Version](https://img.shields.io/pypi/v/letsql)
 ![GitHub License](https://img.shields.io/github/license/letsql/letsql)
 ![PyPI - Status](https://img.shields.io/pypi/status/letsql)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/letsql/letsql/ci-test.yml)
 ![Codecov](https://img.shields.io/codecov/c/github/letsql/letsql)
 
 

--- a/examples/local_cache.py
+++ b/examples/local_cache.py
@@ -4,19 +4,19 @@ import ibis
 
 import letsql as ls
 
+pg = ibis.postgres.connect(
+    host="localhost",
+    port=5432,
+    user="postgres",
+    password="postgres",
+    database="ibis_testing",
+)
+
 con = ls.connect()  # empty connection
 
-con.add_connection(
-    ibis.postgres.connect(
-        host="localhost",
-        port=5432,
-        user="postgres",
-        password="postgres",
-        database="ibis_testing",
-    )
-)  # add Postgres connection
-
-alltypes = con.table("functional_alltypes")
+alltypes = con.register(
+    pg.table("functional_alltypes"), table_name="functional_alltypes"
+)
 
 expr = alltypes.select(alltypes.smallint_col, alltypes.int_col, alltypes.float_col)
 

--- a/examples/multi_engine.py
+++ b/examples/multi_engine.py
@@ -4,18 +4,16 @@ import letsql as ls
 
 con = ls.connect()  # empty connection
 
-con.add_connection(
-    ibis.postgres.connect(
-        host="localhost",
-        port=5432,
-        user="postgres",
-        password="postgres",
-        database="ibis_testing",
-    )
-)  # add Postgres connection
+pg = ibis.postgres.connect(
+    host="localhost",
+    port=5432,
+    user="postgres",
+    password="postgres",
+    database="ibis_testing",
+)
 
-batting = con.table("batting")
-awards_players = con.table("awards_players")
+batting = con.register(pg.table("batting"), table_name="batting")
+awards_players = con.register(pg.table("awards_players"), table_name="awards_players")
 
 left = batting[batting.yearID == 2015]
 right_df = awards_players[awards_players.lgID == "NL"].drop("yearID", "lgID").execute()


### PR DESCRIPTION
Since LetSQL now has the capacity for adding ibis `ir.Table` as a `TableProvider`
we can drop the connection management, this is good because:

- it simplifies the code, no need to handle the connection directly
- from the UX point of view the user doesn't need to add a static reference
- The user doesn't need to learn a new set of methods

Now every time a table is registered, we add the original backend to keep
track of it, to execute single-backend queries on the original
source.

As of now directly executing on the original backend generates issues
when the table name changes (the `test_register_already_existing_table` fails).
So the execution goes through the to_pyarrow_batches method.

Additionally this commit removes unused code and parameters.