### PR TITLE
fix: allow for multiple execution of letsql tables

### DIFF
--- a/python/letsql/backends/let/__init__.py
+++ b/python/letsql/backends/let/__init__.py
@@ -46,14 +46,9 @@ class Backend(DataFusionBackend):
             table = source.op()
             backend = table.source
 
-            if backend.name == self.name:
-                if (original := backend.sources.get(table, self)) != self:
-                    if original != backend:
-                        source = original.table(table.name)
-                        # TODO check how to execute on the original Backend
-                else:
-                    # TODO make a better fix to make the table durable (like a datafusion view)
-                    source = original.table(table.name).to_pyarrow_batches()
+            if backend == self:
+                original = backend.sources.get(table, self)
+                source = original.table(table.name)
 
         registered_table = super().register(source, table_name=table_name, **kwargs)
         self.sources[registered_table.op()] = backend

--- a/src/context.rs
+++ b/src/context.rs
@@ -32,7 +32,7 @@ use crate::provider::PyTableProvider;
 use crate::py_record_batch_provider::PyRecordBatchProvider;
 use crate::udaf::PyAggregateUDF;
 use crate::udf::PyScalarUDF;
-use crate::utils::wait_for_future;
+use crate::utils::{wait_for_completion, wait_for_future};
 
 /// Configuration options for a SessionContext
 #[pyclass(name = "SessionConfig", module = "datafusion", subclass)]
@@ -169,7 +169,7 @@ impl PySessionContext {
     /// Returns a PyDataFrame whose plan corresponds to the SQL statement.
     fn sql(&mut self, query: &str, py: Python) -> PyResult<PyDataFrame> {
         let result = self.ctx.sql(query);
-        let df = wait_for_future(py, result).map_err(DataFusionError::from)?;
+        let df = wait_for_completion(py, result).unwrap();
         Ok(PyDataFrame::new(df))
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,6 +29,14 @@ where
     let runtime: &Runtime = &get_tokio_runtime(py).0;
     py.allow_threads(|| runtime.block_on(f))
 }
+#[allow(clippy::redundant_async_block)]
+pub fn wait_for_completion<F: Future>(py: Python, fut: F) -> F::Output
+where
+    F: Send,
+    F::Output: Send,
+{
+    py.allow_threads(|| futures::executor::block_on(async move { fut.await }))
+}
 
 pub(crate) fn parse_volatility(value: &str) -> Result<Volatility, DataFusionError> {
     Ok(match value {


### PR DESCRIPTION
**Why was a letsql table being executed only once?**

Because when executing the `TableProvider for IbisTable` it would raise:

> Cannot start a runtime from within a runtime. This happens because a function
> (like block_on) attempted to block the current thread while the thread is being
> used to drive asynchronous tasks.

**Why the current code was implemented?**

Because in contrast to `IbisTable`, the `TableProvider for PyRecordBatchProvider`
would not raise an exception, but it had the downside of only being able to
execute it once.

Note there was a TODO to improve it in the future:

```python
# TODO make a better fix to make the table durable (like a datafusion view)
```
**Why the `IbisTable` raised an exception and the `PyRecordBatchProvider` not?**

The best guess is that the IbisTable calls `to_pyarrow_batches`, so there was
a nested call `to_pyarrow_batches` that created a runtime within a runtime.

**Why the current solution works?**
Because it allows to create a runtime within a runtime, see this [post](
https://medium.com/@greptime_team/bridging-async-and-sync-rust-code-a-lesson-learned-while-working-with-tokio-6173b1efaca4) and also the discussion [herein](https://www.reddit.com/r/rust/comments/11nyax9/bridging_async_and_sync_rust_code_a_lesson/)

closes #39 