### PR TITLE
chore: add automatic testing for examples dir

### DIFF
--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -1,8 +1,12 @@
+import pathlib
+
 import letsql as ls
+
 
 con = ls.connect()
 
-iris = con.read_csv("data/iris.csv", "iris")
+iris_data_path = pathlib.Path(__file__).absolute().parent / "data" / "iris.csv"
+iris = con.read_csv(iris_data_path, "iris")
 
 res = (
     iris.filter([iris.sepal_length > 5])

--- a/python/letsql/tests/test_examples.py
+++ b/python/letsql/tests/test_examples.py
@@ -1,0 +1,24 @@
+import pathlib
+import runpy
+import pytest
+
+from letsql.backends.let import KEY_PREFIX
+
+file_path = pathlib.Path(__file__).absolute()
+root = file_path.parent
+examples_dir = file_path.parents[3] / "examples"
+scripts = examples_dir.glob("*.py")
+
+
+def teardown_function():
+    """Remove any generated parquet cache files"""
+    for path in root.glob(f"{KEY_PREFIX}*"):
+        path.unlink(missing_ok=True)
+
+    for path in pathlib.Path.cwd().glob(f"{KEY_PREFIX}*"):
+        path.unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize("script", scripts)
+def test_script_execution(script):
+    runpy.run_path(str(script))


### PR DESCRIPTION
In the past code changes have broken the scripts in the example directory

This commit ensures code changes won't break example functionality without breaking the test suite.

Inspired by this
https://x.com/samuel_colvin/status/1785113080696872980