### PR TITLE
feat: improve postgres table caching / cache invalidation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -167,6 +167,7 @@
           ] ++ (builtins.attrValues letsql-commands);
         };
         shellHook = ''
+          export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
           ${letsql-commands.letsql-ensure-download-data}/bin/letsql-ensure-download-data
         '';
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -938,7 +938,6 @@ optional = false
 python-versions = ">=3.9"
 files = [
     {file = "pandas-2.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:90c6fca2acf139569e74e8781709dccb6fe25940488755716d1d354d6bc58bce"},
-    {file = "pandas-2.2.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c7adfc142dac335d8c1e0dcbd37eb8617eac386596eb9e1a1b77791cf2498238"},
     {file = "pandas-2.2.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4abfe0be0d7221be4f12552995e58723c7422c80a659da13ca382697de830c08"},
     {file = "pandas-2.2.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8635c16bf3d99040fdf3ca3db669a7250ddf49c55dc4aa8fe0ae0fa8d6dcc1f0"},
     {file = "pandas-2.2.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:40ae1dffb3967a52203105a077415a86044a2bea011b5f321c6aa64b379a3f51"},
@@ -959,7 +958,6 @@ files = [
     {file = "pandas-2.2.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:43498c0bdb43d55cb162cdc8c06fac328ccb5d2eabe3cadeb3529ae6f0517c32"},
     {file = "pandas-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:d187d355ecec3629624fccb01d104da7d7f391db0311145817525281e2804d23"},
     {file = "pandas-2.2.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0ca6377b8fca51815f382bd0b697a0814c8bda55115678cbc94c30aacbb6eff2"},
-    {file = "pandas-2.2.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9057e6aa78a584bc93a13f0a9bf7e753a5e9770a30b4d758b8d5f2a62a9433cd"},
     {file = "pandas-2.2.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:001910ad31abc7bf06f49dcc903755d2f7f3a9186c0c040b827e522e9cef0863"},
     {file = "pandas-2.2.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66b479b0bd07204e37583c191535505410daa8df638fd8e75ae1b383851fe921"},
     {file = "pandas-2.2.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:a77e9d1c386196879aa5eb712e77461aaee433e54c68cf253053a73b7e49c33a"},

--- a/python/letsql/common/utils/postgres_utils.py
+++ b/python/letsql/common/utils/postgres_utils.py
@@ -1,0 +1,41 @@
+def do_checkpoint(con):
+    con.raw_sql("CHECKPOINT")
+
+
+def do_analyze(con, name):
+    con.raw_sql(f"ANALYZE \"{name}\"")
+
+
+def get_postgres_n_changes(dt):
+    (con, name, schemaname) = (dt.source, dt.name, dt.namespace.catalog or "public")
+    sql = f"""
+        SELECT n_tup_upd + n_tup_ins + n_tup_del AS n_changes FROM pg_stat_user_tables
+        WHERE relname = '{name}' AND schemaname = '{schemaname}';
+    """
+    do_checkpoint(con)
+    do_analyze(con, name)
+    ((n_changes,),) = con.sql(sql).execute().values
+    return n_changes
+
+
+def get_postgres_n_reltuples(dt):
+    (con, name) = (dt.source, dt.name)
+    sql = f"""
+        SELECT reltuples
+        FROM pg_class
+        WHERE relname = '{name}'
+    """
+    do_checkpoint(con)
+    do_analyze(con, name)
+    ((n_reltuples,),) = con.sql(sql).execute().values
+    return n_reltuples
+
+
+def get_postgres_n_scans(dt):
+    (con, name, schemaname) = (dt.source, dt.name, dt.namespace.catalog or "public")
+    sql = f"""
+        SELECT seq_scan FROM pg_stat_user_tables
+        WHERE relname = '{name}' AND schemaname = '{schemaname}';
+    """
+    ((n_scans,),) = con.sql(sql).execute().values
+    return n_scans


### PR DESCRIPTION
- add better caching of postgres tables by checking information postgres' system catalogs
- add test of postgres cache invalidation upon table modification
- modify conftest to remove all "unexpected" tables from postgres database
- add environment variable to prevent poetry from hanging on keyring issues