### PR TITLE
fix(pre-commit): explicitly install poetry-plugin-export per warning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,5 +46,8 @@ repos:
       -   id: poetry-lock
           args: ["--no-update"]
       -   id: poetry-install
+  -   repo: https://github.com/python-poetry/poetry-plugin-export
+      rev: 1.8.0
+      hooks:
       -   id: poetry-export
           args: ["--with", "dev", "--no-ansi", "--without-hashes", "-f", "requirements.txt", "-o", "requirements-dev.txt"]


### PR DESCRIPTION
```
codespell................................................................Passed
ruff.................................................(no files to check)Skipped
ruff-format..........................................(no files to check)Skipped
Rust fmt.............................................(no files to check)Skipped
Rust clippy..........................................(no files to check)Skipped
poetry-check.............................................................Passed
poetry-lock..............................................................Passed
poetry-export............................................................Failed
- hook id: poetry-export
- files were modified by this hook

Warning: poetry-plugin-export will not be installed by default in a future version of Poetry.
In order to avoid a breaking change and make your automation forward-compatible, please install poetry-plugin-export explicitly. See https://python-poetry.org/docs/plugins/#using-plugins for details on how to install a plugin.
To disable this warning run 'poetry config warnings.export false'.
```