### PR TITLE
fix: normalize_memory_databasetable: incrementally tokenize RecordBatchs

### DIFF
--- a/python/letsql/common/utils/dask_normalize_expr.py
+++ b/python/letsql/common/utils/dask_normalize_expr.py
@@ -32,7 +32,10 @@ def normalize_memory_databasetable(dt):
             dt.source,
             dt.schema.to_pandas(),
             # in memory: so we can assume its reasonable to hash the data
-            dt.to_expr().to_pandas(),
+            tuple(
+                dask.base.tokenize(el.serialize().to_pybytes())
+                for el in dt.to_expr().to_pyarrow_batches()
+            ),
         )
     )
 

--- a/python/letsql/common/utils/tests/test_dask_normalize.py
+++ b/python/letsql/common/utils/tests/test_dask_normalize.py
@@ -23,7 +23,7 @@ def test_tokenize_datafusion_memory_expr(alltypes_df):
     con = ibis.datafusion.connect()
     t = con.register(alltypes_df, "t")
     actual = dask.base.tokenize(t)
-    expected = "6b8a64cd132d212ce4b2af1e2b403316"
+    expected = "e5feefe7661d275607da0e0a089e2c3e"
     assert actual == expected
 
 


### PR DESCRIPTION
rather than pull of all the table into memory at once, tokenize batches generated by `to_pyarrow_batches`