### PR TITLE
fix: cannot create table

### DIFF
--- a/python/letsql/backends/datafusion/__init__.py
+++ b/python/letsql/backends/datafusion/__init__.py
@@ -29,7 +29,7 @@ import letsql
 import letsql.internal as df
 from letsql.backends.datafusion.compiler import DataFusionCompiler
 from letsql.backends.datafusion.provider import IbisTableProvider
-from letsql.internal import SessionConfig, SessionContext, TableProvider
+from letsql.internal import SessionConfig, SessionContext, TableProvider, Table
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -372,8 +372,12 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
             self.con.deregister_table(table_name)
             self.con.register_record_batch_reader(table_name, source)
             return self.table(table_name)
+        elif isinstance(source, Table):
+            self.con.deregister_table(table_name)
+            self.con.register_table(table_name, source)
+            return self.table(table_name)
         else:
-            raise ValueError("`source` must be either a string or a pathlib.Path")
+            raise ValueError(f"Unknown `source` type {type(source)}")
 
         if first.startswith(("parquet://", "parq://")) or first.endswith(
             ("parq", "parquet")

--- a/python/letsql/backends/let/tests/test_client.py
+++ b/python/letsql/backends/let/tests/test_client.py
@@ -41,3 +41,11 @@ def test_register_record_batch_reader_with_filter(alltypes, alltypes_df):
     cols_a = [ca for ca in alltypes.columns.copy() if ca != "timestamp_col"]
     expr = t2.filter((t2.id >= 5200) & (t2.id <= 5210))[cols_a]
     expr.execute()
+
+
+def test_create_table(con):
+    import ibis
+    import pandas as pd
+
+    con.create_table("UPPERCASE", schema=ibis.schema({"A": "int"}))
+    con.create_table("name", pd.DataFrame({"a": [1]}))

--- a/python/letsql/internal.py
+++ b/python/letsql/internal.py
@@ -15,6 +15,7 @@ from ._internal import (
     SessionContext,  # noqa: F401
     SessionState,  # noqa: F401
     TableProvider,
+    Table,
 )
 
 __all__ = [
@@ -32,6 +33,7 @@ __all__ = [
     "OptimizationRule",
     "TableProvider",
     "AbstractTableProvider",
+    "Table",
 ]
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ fn _internal(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<optimizer::PyOptimizerContext>()?;
     m.add_class::<optimizer::PyOptimizerRule>()?;
     m.add_class::<provider::PyTableProvider>()?;
+    m.add_class::<catalog::PyTable>()?;
 
     // Register `common` as a submodule. Matching `datafusion-common` https://docs.rs/datafusion-common/latest/datafusion_common/
     let common = PyModule::new(py, "common")?;
@@ -77,10 +78,6 @@ fn _internal(py: Python, m: &PyModule) -> PyResult<()> {
     let builder = PyModule::new(py, "builder")?;
     builder::init_module(builder)?;
     m.add_submodule(builder)?;
-
-    let provider = PyModule::new(py, "provider")?;
-    builder::init_module(provider)?;
-    m.add_submodule(provider)?;
 
     Ok(())
 }


### PR DESCRIPTION
Currently creating a table results in the following PanicException

```
there is no reactor running, must be called from the context of a Tokio 1.x runtime
```

that is because we don't use Tokio when executing a SQL query,
to be able to register LETSQL tables inside LETSQL

The solution is to treat the registration of DataFusion-backed tables
separately and use the original table to avoid calling to py_arrow_batches

closes #71