### PR TITLE
fix: change name of parameter in replace_table function

### DIFF
--- a/python/letsql/backends/let/hotfix.py
+++ b/python/letsql/backends/let/hotfix.py
@@ -95,8 +95,8 @@ class LETSQLAccessor:
     def native_expr(self):
         _sources = self.ls_con._sources
 
-        def replace_table(n, _, **_kwargs):
-            return _sources.get_table_or_op(n, n.__recreate__(_kwargs))
+        def replace_table(_node, _, **_kwargs):
+            return _sources.get_table_or_op(_node, _node.__recreate__(_kwargs))
 
         return self.op.replace(replace_table).to_expr()
 

--- a/python/letsql/backends/let/tests/test_cache.py
+++ b/python/letsql/backends/let/tests/test_cache.py
@@ -533,3 +533,18 @@ def test_register_with_different_name_and_cache(con, csv_dir, get_expr):
 
     assert table_name != letsql_table_name
     assert expr.execute() is not None
+
+
+def test_replace_table_matching_kwargs(pg, ls_con, tmp_path):
+    storage = ParquetCacheStorage(
+        source=ls_con,
+        path=tmp_path,
+    )
+    expr = (
+        pg.table("batting")
+        .pipe(ls_con.register, "pg-batting")[lambda t: t.yearID > 2014]
+        .limit(1)
+        .cache(storage=storage)
+    )
+
+    assert expr.ls.native_expr is not None

--- a/python/letsql/expr/relations.py
+++ b/python/letsql/expr/relations.py
@@ -30,8 +30,8 @@ def make_native_op(node):
     if native_source.name == "let":
         raise ValueError
 
-    def replace_table(n, _, **_kwargs):
-        return sources.get_table_or_op(n, n.__recreate__(_kwargs))
+    def replace_table(_node, _, **_kwargs):
+        return sources.get_table_or_op(_node, _node.__recreate__(_kwargs))
 
     return node.replace(replace_table).to_expr()
 


### PR DESCRIPTION
The name `n `clashes with operations/expressions containing arguments with that name, such as limit.

The root of the issue is that the map function creates a `kwargs` dictionary containing as keys the operation's arguments.

When the name of one of the operation's arguments matches the name of the first argument, an issue arises.