### PR TITLE
chore: add unit tests based on workflow diagram

### DIFF
--- a/examples/remote_caching.py
+++ b/examples/remote_caching.py
@@ -1,0 +1,33 @@
+import pathlib
+
+import ibis
+import letsql as ls
+from letsql.common.caching import SourceStorage
+
+con = ls.connect()
+ddb = ibis.duckdb.connect()
+pg = ibis.postgres.connect(
+    host="localhost",
+    port=5432,
+    user="postgres",
+    password="postgres",
+    database="ibis_testing",
+)
+
+root = pathlib.Path(__file__).absolute().parents[1]
+path = root / "ci" / "ibis-testing-data" / "parquet" / "batting.parquet"
+right = ddb.read_parquet(path, table_name="batting")[lambda t: t.yearID == 2014].pipe(
+    con.register, table_name="ddb-batting"
+)
+
+left = pg.table("batting")[lambda t: t.yearID == 2015].pipe(
+    con.register, table_name="pg-batting"
+)
+
+expr = left.join(
+    right,
+    "playerID",
+).cache(SourceStorage(pg))
+
+res = expr.execute()
+print(res)

--- a/python/letsql/common/caching.py
+++ b/python/letsql/common/caching.py
@@ -155,7 +155,8 @@ class SourceStorage(CacheStorage):
     def _put(self, key, value):
         expr = value.to_expr()
         backends, _ = expr._find_backends()
-        if set(backends) == set((self.source,)):
+        # FIXME what happens when the backend is LETSQL, to_pyarrow won't work
+        if all(self.source is backend for backend in backends) and len(backends) == 1:
             self.source.create_table(key, expr)
         else:
             self.source.create_table(key, expr.to_pyarrow())


### PR DESCRIPTION
- create new unit test to detect and fix problems obtained from the workflow diagram analysis

- fixes the problem with using set or equals for testing equality among backends, currently the hashing of backends is based on string of the name of the class, which renders all backends equals

- fix problem normalize_duckdb_databasetable to handle SEQ_SCAN and duckdb tables

- fix node replacement, now it is a LETSQL op. Before calling .cache at the end of expr causes the expr source to become the source of the cache, leaving letsql and entering into ibis.

- also add tests to verify that execution happens in the native backend

workflow diagram reference: https://excalidraw.com/#json=rmcDKw_OB0hoZ7B2O4NKO,TXGXMJ38zb1Ly3NwXgaVcw