### PR TITLE
chore: unpin pyarrow version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3140,4 +3140,4 @@ snowflake = ["snowflake-connector-python"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c8ee857c75f272dacaa8bb19fe700e9d3cd525f87844e26cb594e29030c71cc8"
+content-hash = "c4a002f27f7c63e345692571bbbde76d3b3d3c4db53789d162750f72bdcabeb8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "connectorx==0.3.2 ; python_version >= '3.10' and python_version < '4.0'",
     "psycopg2-binary==2.9.9 ; python_version >= '3.10' and python_version < '4.0'",
     "sqlalchemy==2.0.29 ; python_version >= '3.10' and python_version < '4.0'",
-    "pyarrow==13.0.0 ; python_version >= '3.10' and python_version < '4.0'",
+    "pyarrow>=13.0.0 ; python_version >= '3.10' and python_version < '4.0'",
     "structlog==24.2.0 ; python_version >= '3.10' and python_version < '4.0'",
     "pytest-mock==3.14.0 ; python_version >= '3.10' and python_version < '4.0'",
 ]
@@ -85,7 +85,7 @@ attrs = "^23.2.0"
 connectorx = "^0.3.2"
 psycopg2-binary = "^2.9.9"
 sqlalchemy = "^2.0.25"
-pyarrow = "13.0.0"
+pyarrow = ">=13.0.0"
 duckdb = {version = "^0.10.3", optional = true}
 snowflake-connector-python = {version = "^3.10.1", optional = true}
 datafusion = {version = "^34.0.0", optional = true}


### PR DESCRIPTION
The change was tested on a project with the following pyproject.toml

```toml
[tool.poetry]
name = "test-letsql"
version = "0.1.0"
description = ""
authors = ["Daniel Mesejo <mesejoleon@gmail.com>"]
readme = "README.md"

[tool.poetry.dependencies]
python = "^3.10"
pyarrow = "15.0.0"
letsql = {path = "/home/daniel/PycharmProjects/public-letsql/target/wheels/letsql-0.1.4-cp38-abi3-manylinux_2_35_x86_64.whl"}

[build-system]
requires = ["poetry-core"]
build-backend = "poetry.core.masonry.api"
```