### PR TITLE
chore: disable pip_requirements manager

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,6 @@
     "github-actions",
     "pep621",
     "poetry",
-    "pip_requirements",
     "cargo"
   ],
   "prHourlyLimit": 3,


### PR DESCRIPTION
The manager changes the requirements-dev.txt file, this file is generated automatically from poetry export command, so there is no need to change it manually. Moreover is creating duplicated noisy PRs