### PR TITLE
nix editable install

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -12,5 +12,6 @@ export NIX_CONF_DIR=$(realpath ./nix)
 export NIX_USER_CONF_FILES=$(realpath ./nix)
 watch_file pyproject.toml poetry.lock
 watch_file nix/commands.nix
-# use `use nix` to develop via venv workflow
 use flake
+# use `use nix` for "editable" install
+# use nix

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,10 @@
       let
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [ (import rust-overlay) ];
+          overlays = [
+            (import rust-overlay)
+            poetry2nix.overlays.default
+          ];
         };
         mkLETSQL = (import ./nix/letsql.nix { inherit system pkgs poetry2nix crane; }) ./.;
         mkCommands = python: import ./nix/commands.nix {

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,6 @@
           name = "tools-${python.pythonVersion}";
           paths = [
             letsql.toolchain
-            pkgs.maturin
             pkgs.poetry
             python
             commands.letsql-commands-star
@@ -54,6 +53,7 @@
         in pkgs.mkShell {
           packages = [
             toolsPackages
+            pkgs.maturin
           ];
           inherit shellHook;
         };
@@ -99,6 +99,7 @@
         lib = {
           inherit (letsql310) poetryOverrides maturinOverride;
           inherit mkLETSQL mkCommands mkShellHook mkToolsPackages mkDevShell;
+          inherit pkgs;
         };
         devShells = {
           inherit tools310 tools311 tools312;

--- a/nix/letsql.nix
+++ b/nix/letsql.nix
@@ -119,7 +119,7 @@ let
     };
   in {
     inherit toolchain;
-    inherit rustSrcSet pySrcSet crateWheelSrc;
+    inherit rustSrcSet pySrcSet rustSrc pySrc crateWheelSrc;
     inherit poetryOverrides maturinOverride;
     inherit app appFromWheel;
   };

--- a/nix/letsql.nix
+++ b/nix/letsql.nix
@@ -87,6 +87,14 @@ let
           cd ..
         '';
       });
+      scipy = prev.scipy.overridePythonAttrs (old: {
+      } // pkgs.lib.attrsets.optionalAttrs pkgs.stdenv.isDarwin {
+        nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.xcbuild.xcrun ];
+      });
+      scikit-learn = prev.scikit-learn.overridePythonAttrs (old: {
+      } // pkgs.lib.attrsets.optionalAttrs pkgs.stdenv.isDarwin {
+        nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ prev.meson-python ];
+      });
     };
     maturinOverride = old: with pkgs.rustPlatform; {
       cargoDeps = importCargoLock {

--- a/shell.nix
+++ b/shell.nix
@@ -1,128 +1,41 @@
-with (import <nixpkgs> {});
 let
-  this-dir = toString ./.;
-  venv-path = toString ./venv;
-  python-bin = "${pkgs.python310}/bin/python";
-  pb-ver = "25.1";
-  protoc-target = "~/.local";
-  cargo-target = "~/.cargo";
+  flake = builtins.getFlake (toString ./.);
+  inherit (flake.lib.${builtins.currentSystem}) pkgs mkToolsPackages;
+  inherit (flake.inputs.poetry2nix.lib.mkPoetry2Nix { inherit pkgs; }) mkPoetryEnv;
 
-  ensure-cargo = pkgs.writeShellScriptBin "ensure-cargo" ''
-    set -eux
+  python = pkgs.python310;
 
-    target=${cargo-target}
-    if [ ! -d "$target" ]; then
-      ${pkgs.bash}/bin/bash <(
-        ${pkgs.curl}/bin/curl \
-          --proto '=https' \
-          --tlsv1.2 -sSf https://sh.rustup.rs \
-        ) \
-        --no-modify-path \
-        -y
-
-        if [ ! -d "$target" ]; then
-          echo "$target doesn't exist after running rustup install"
-          exit 1
-        fi
-    fi
-  '';
-
-  ensure-protoc = pkgs.writeShellScriptBin "ensure-protoc" ''
-    set -eux
-
-    pb_ver=''${1:-${pb-ver}}
-    target=''${2:-${protoc-target}}
-
-    echo $target
-    if [ ! -f "$target/bin/protoc" ]; then
-      zip_name="protoc-$pb_ver-linux-x86_64.zip"
-      PB_REL="https://github.com/protocolbuffers/protobuf/releases"
-      curl -LO "$PB_REL/download/v$pb_ver/$zip_name"
-      unzip "$zip_name" -d "$target"
-      rm "$zip_name"
-    fi
-    echo $target
-  '';
-
-  ensure-pre-commit-installed = pkgs.writeShellScriptBin "ensure-pre-commit-installed" ''
-    test -x ${this-dir}/.git/hooks/pre-commit || {
-      cd ${this-dir} && \
-        ${pkgs.pre-commit}/bin/pre-commit install
-    }
-  '';
-
-  make-venv = pkgs.writeShellScriptBin "make-venv" ''
-    ${python-bin} -m venv --without-pip "${venv-path}"
-    source ${venv-path}/bin/activate
-    python <(${pkgs.curl}/bin/curl https://bootstrap.pypa.io/get-pip.py)
-    pip install poetry
-    cd ${this-dir}
-    poetry check
-    poetry install --no-root
-  '';
-
-  letsql-ensure-setup = pkgs.writeShellScriptBin "letsql-ensure-setup" ''
-    set -eux
-    ${ensure-cargo}/bin/ensure-cargo
-    ${ensure-protoc}/bin/ensure-protoc
-    ${ensure-pre-commit-installed}/bin/ensure-pre-commit-installed
-    if [ ! -d ${venv-path} ]; then
-      ${make-venv}/bin/make-venv
-    fi
-  '';
-
-  letsql-maturin-develop = pkgs.writeShellScriptBin "letsql-maturin-develop" ''
-    source ${venv-path}/bin/activate
-    cd ${this-dir}
-    maturin develop
-  '';
-
-  letsql-docker-compose-up = pkgs.writeShellScriptBin "letsql-docker-compose-up" ''
-    set -eux
-    docker compose up
-    # docker compose up --build --force-recreate --no-deps
-  '';
-
-  letsql-docker-compose-down-volumes = pkgs.writeShellScriptBin "letsql-docker-compose-down-volumes" ''
-    set -eux
-    docker compose down --volumes
-  '';
-
-  letsql-sudo-usermod-append-docker = pkgs.writeShellScriptBin "letsql-usermod-append-docker" ''
-    set -eux
-    sudo usermod --append --groups docker $USER
-  '';
-
-  letsql-newgrp-docker = pkgs.writeShellScriptBin "letsql-newgrp-docker" ''
-    set -eux
-    newgrp docker
-  '';
-
+  editableApp = mkPoetryEnv {
+    projectDir = ./.;
+    inherit python;
+    preferWheels = true;
+    groups = [ "dev" "test" "docs" ];
+    editablePackageSources = {
+      letsql = ./python;
+    };
+  };
+  toolsPackages = mkToolsPackages editableApp;
 in pkgs.mkShell {
-  shellHook = ''
-    # work around poetry keyring issue
-    export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
-    export PATH=${protoc-target}/bin:${cargo-target}/bin:$PATH
-
-    ${letsql-ensure-setup}/bin/letsql-ensure-setup
-    source ${venv-path}/bin/activate
-    python -c 'import letsql' >/dev/null 2>/dev/null || {
-      # unclear why we can't run this inside shell hook, but it always fails on the first run
-      echo "initial population required, run
-        letsql-maturin-develop"
-    }
-  '';
-  packages = with pkgs; [
-    letsql-ensure-setup
-    letsql-maturin-develop
-
-    letsql-docker-compose-up
-    letsql-docker-compose-down-volumes
-    letsql-sudo-usermod-append-docker
-    letsql-newgrp-docker
-
-    pre-commit
-    just
+  packages = [
+    editableApp
+    toolsPackages
+    pkgs.poetry
   ];
-  LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib";
+  shellHook = ''
+    repo_dir=$(git rev-parse --show-toplevel)
+    if [ "$(basename "$repo_dir")" != "letsql" ]; then
+      echo "not in letsql, exiting"
+      exit 1
+    fi
+    source=$repo_dir/target/debug/maturin/libletsql.so
+    target=$repo_dir/python/letsql/_internal.abi3.so
+    if [ ! -f "$target" ]; then
+      maturin build
+      ln -s "$source" "$target"
+    fi
+    if [ "$(realpath "$source")" != "$(realpath "$target")" ]; then
+      rm "$target"
+      ln -s "$source" "$target"
+    fi
+  '';
 }


### PR DESCRIPTION
enables editing `.envrc` to use non-flake nix to work with an editable install

```
diff --git a/.envrc b/.envrc
index 8f99741..f4a187e 100644
--- a/.envrc
+++ b/.envrc
@@ -12,6 +12,6 @@ export NIX_CONF_DIR=$(realpath ./nix)
 export NIX_USER_CONF_FILES=$(realpath ./nix)
 watch_file pyproject.toml poetry.lock
 watch_file nix/commands.nix
-use flake
+# use flake
 # use `use nix` for "editable" install
-# use nix
+use nix
```