### PR TITLE
fix: use pandas backend in SourceStorage

### DIFF
--- a/python/letsql/backends/let/__init__.py
+++ b/python/letsql/backends/let/__init__.py
@@ -208,7 +208,7 @@ class Backend(DataFusionBackend):
         if backend is self:
             backend = super()
 
-        return backend.execute(expr, **kwargs)
+        return backend.execute(expr.unbind(), **kwargs)
 
     def _transform_to_native_backend(self, expr):
         native_backend = self._get_source(expr) is not self

--- a/python/letsql/backends/let/tests/test_cache.py
+++ b/python/letsql/backends/let/tests/test_cache.py
@@ -838,3 +838,15 @@ def test_udaf_caching(ls_con, alltypes_df, snapshot):
 
     snapshot.assert_match(expr.ls.get_key(), "test_udaf_caching.txt")
     snapshot.assert_match(on_expr.ls.get_key(), "test_udaf_caching.txt")
+
+
+def test_caching_pandas(ls_con, csv_dir):
+    diamonds_path = csv_dir / "diamonds.csv"
+    pandas_con = letsql.pandas.connect()
+    cache = SourceStorage(source=pandas_con)
+    t = (
+        pandas_con.read_csv(diamonds_path)
+        .pipe(ls_con.register, "DIAMONDS")
+        .cache(storage=cache)
+    )
+    assert t.execute() is not None

--- a/python/letsql/common/caching.py
+++ b/python/letsql/common/caching.py
@@ -159,7 +159,11 @@ class SourceStorage(CacheStorage):
         expr = value.to_expr()
         backends, _ = expr._find_backends()
         # FIXME what happens when the backend is LETSQL, to_pyarrow won't work
-        if all(self.source is backend for backend in backends) and len(backends) == 1:
+        if (
+            len(backends) == 1
+            and backends[0].name != "pandas"
+            and backends[0] is self.source
+        ):
             self.source.create_table(key, expr)
         else:
             self.source.create_table(key, expr.to_pyarrow())


### PR DESCRIPTION
**Why was the setting as the source of the SourceStorage cache failing?**

The pandas backend needs to learn how to create a table from an ibis expression.

**Why do we need to execute the unbound expr?**

The panda's executor assumes the expr is bound to pandas and will search for the dictionary attribute.

The SQL backends create an SQL string from the expr.

Moreover, executing unbound expr pushes the code in the right direction.

closes #192 