### PR TITLE
nix run

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,19 @@
         dev310 = mkDevShell pkgs.python310;
         dev311 = mkDevShell pkgs.python311;
         dev312 = mkDevShell pkgs.python312;
+        #
+        mkShellApp = drv: name: bin-name: pkgs.writeShellApplication {
+          inherit name;
+          runtimeInputs = [ ];
+          text = ''
+            bash <(
+              cat <(grep ^declare ${drv}) <(echo ${bin-name} "''${@}")
+            )
+          '';
+        };
+        letsql-ipython-310 = mkShellApp dev310 "letsql-ipython-310" "ipython";
+        letsql-ipython-311 = mkShellApp dev311 "letsql-ipython-311" "ipython";
+        letsql-ipython-312 = mkShellApp dev312 "letsql-ipython-312" "ipython";
       in
       {
         packages = {
@@ -90,11 +103,14 @@
           app312 = letsql312.app;
           appFromWheel312 = letsql312.appFromWheel;
           inherit toolsPackages310 toolsPackages311 toolsPackages312;
+          inherit letsql-ipython-310 letsql-ipython-311 letsql-ipython-312;
           #
           app = self.packages.${system}.app310;
           appFromWheel = self.packages.${system}.appFromWheel310;
           toolsPackages = self.packages.${system}.toolsPackages310;
-          default = self.packages.${system}.appFromWheel;
+          letsql = self.packages.${system}.letsql-ipython-310;
+          #
+          default = self.packages.${system}.letsql;
         };
         lib = {
           inherit (letsql310) poetryOverrides maturinOverride;

--- a/python/letsql/common/utils/logging_utils.py
+++ b/python/letsql/common/utils/logging_utils.py
@@ -62,7 +62,7 @@ def get_log_path(log_path=default_log_path):
     try:
         log_path.parent.mkdir(exist_ok=True, parents=True)
     except Exception:
-        log_path = tempfile.mkstemp(suffix=".log", prefix="letsql-")
+        (_, log_path) = tempfile.mkstemp(suffix=".log", prefix="letsql-")
     return log_path
 
 

--- a/python/letsql/common/utils/tests/test_logging.py
+++ b/python/letsql/common/utils/tests/test_logging.py
@@ -1,9 +1,13 @@
+import pathlib
+
 import pytest
 import structlog
-
 from structlog.testing import LogCapture
 
-from letsql.common.utils.logging_utils import log_initial_state
+from letsql.common.utils.logging_utils import (
+    get_log_path,
+    log_initial_state,
+)
 
 
 @pytest.fixture(name="log_output")
@@ -32,3 +36,11 @@ def test_logging_without_git(log_output, tmp_path):
 
     assert not _has_event(log_output.entries, "git state")
     assert _has_event(log_output.entries, "letsql version")
+
+
+def test_temp_log_path():
+    bad_log_path = "/nonexistantandunwritablepath/"
+    log_path = pathlib.Path(get_log_path(bad_log_path))
+    assert log_path.exists()
+    with pytest.raises(ValueError):
+        log_path.relative_to(bad_log_path)

--- a/shell.nix
+++ b/shell.nix
@@ -26,18 +26,14 @@ let
     fi
     case $(uname) in
       Darwin) suffix=dylib ;;
-      *) suffix=so ;;
+      *)      suffix=so    ;;
     esac
     source=$repo_dir/target/debug/maturin/libletsql.$suffix
     target=$repo_dir/python/letsql/_internal.abi3.so
     if [ ! -e "$source" ]; then
-      maturin build
+      ${toolsPackages}/bin/maturin build
     fi
-    if [ ! -L "$target" ]; then
-      rm -f "$target"
-      ln -s "$source" "$target"
-    fi
-    if [ "$(realpath "$source")" != "$(realpath "$target")" ]; then
+    if [ ! -L "$target" -o "$(realpath "$source")" != "$(realpath "$target")" ]; then
       rm -f "$target"
       ln -s "$source" "$target"
     fi


### PR DESCRIPTION
this branch is testable with `nix run github:letsql/letsql/nix-run`
once merged, people can try letsql out with `nix run github:letsql/letsql`
for a specific python version, 312 for example, they can run `nix run github:letsql/letsql#letsql-ipython-312`