### PR TITLE
fix(udf): remove  wrap so that the udf keeps its metadata

### DIFF
--- a/python/letsql/backends/datafusion/__init__.py
+++ b/python/letsql/backends/datafusion/__init__.py
@@ -553,17 +553,16 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         partial = toolz.functoolz.partial(construct, model_name)
 
         def create_named_wrapper(func, name, signature):
-            def register_xgb_model(*args, **kwargs):
+            def predict_xgb(*args, **kwargs):
                 return func(*args, **kwargs)
 
             new_func = types.FunctionType(
-                register_xgb_model.__code__,
-                register_xgb_model.__globals__,
+                predict_xgb.__code__,
+                predict_xgb.__globals__,
                 name=name,
-                argdefs=register_xgb_model.__defaults__,
-                closure=register_xgb_model.__closure__,
+                argdefs=predict_xgb.__defaults__,
+                closure=predict_xgb.__closure__,
             )
-            new_func = functools.wraps(func)(new_func)
             new_func.__signature__ = signature
             return new_func
 


### PR DESCRIPTION
fixed
``` python
<function functools.register_xgb_model(carat: Float64(nullable=True), depth: Float64(nullable=True), x: Float64(nullable=True), y: Float64(nullable=True), z: Float64(nullable=True))>
```
to
```python
<function letsql.backends.datafusion.predict_xgb(carat: Float64(nullable=True), depth: Float64(nullable=True), x: Float64(nullable=True), y: Float64(nullable=True), z: Float64(nullable=True))>
```