### PR TITLE
feat/no expr registration

### DIFF
--- a/examples/multi_engine.py
+++ b/examples/multi_engine.py
@@ -1,3 +1,5 @@
+import ibis
+
 import letsql as ls
 
 

--- a/examples/multi_engine.py
+++ b/examples/multi_engine.py
@@ -1,6 +1,5 @@
 import letsql as ls
 
-# this example also shows the no need for registering tables or expression directly in LETSQL
 
 pg = ls.postgres.connect_examples()
 db = ls.duckdb.connect()
@@ -18,8 +17,3 @@ expr = left.join(right, ["playerID"], how="semi")[["yearID", "stint"]]
 
 result = expr.execute()
 print(result)
-result = expr.to_pyarrow()
-print(result)
-result = expr.to_pyarrow_batches().read_pandas()
-print(result)
-print(tuple(dt.args for dt in expr.ls.native_dts))

--- a/examples/multi_engine.py
+++ b/examples/multi_engine.py
@@ -1,23 +1,20 @@
-import ibis
-
 import letsql as ls
 
 
-con = ls.connect()  # empty connection
 pg = ls.postgres.connect_examples()
 db = ls.duckdb.connect()
 
 
-batting = pg.table("batting").pipe(con.register, table_name="batting")
+batting = pg.table("batting")
 awards_players = db.register(
     ls.config.options.pins.get_path("awards_players"),
     table_name="awards_players",
-).pipe(con.register, "db-awards_players")
+)
 
 
 left = batting[batting.yearID == 2015]
 right = awards_players[awards_players.lgID == "NL"].drop("yearID", "lgID")
-expr = left.join(right, ["playerID"], how="semi")
+expr = left.join(right, ["playerID"], how="semi")[["yearID", "stint"]]
 result = expr.execute()
 
 

--- a/examples/multi_engine.py
+++ b/examples/multi_engine.py
@@ -1,5 +1,6 @@
 import letsql as ls
 
+# this example also shows the no need for registering tables or expression directly in LETSQL
 
 pg = ls.postgres.connect_examples()
 db = ls.duckdb.connect()
@@ -10,13 +11,15 @@ awards_players = db.register(
     ls.config.options.pins.get_path("awards_players"),
     table_name="awards_players",
 )
-
-
 left = batting[batting.yearID == 2015]
 right = awards_players[awards_players.lgID == "NL"].drop("yearID", "lgID")
 expr = left.join(right, ["playerID"], how="semi")[["yearID", "stint"]]
+
+
 result = expr.execute()
-
-
+print(result)
+result = expr.to_pyarrow()
+print(result)
+result = expr.to_pyarrow_batches().read_pandas()
 print(result)
 print(tuple(dt.args for dt in expr.ls.native_dts))

--- a/examples/predict_xgb.py
+++ b/examples/predict_xgb.py
@@ -13,7 +13,7 @@ with tempfile.TemporaryDirectory() as tmp_dir:
     predict_xgb = con.register_xgb_model(model_name, model_path)
     cache = ParquetCacheStorage(source=con, path=tmp_dir)
     pg = ls.postgres.connect_examples()
-    t = pg.table("diamonds").pipe(con.register, "diamonds").cache(storage=cache)
+    t = pg.table("diamonds").cache(storage=cache)
 
     output = t.mutate(prediction=predict_xgb.on_expr).execute()
     print(output)

--- a/examples/remote_caching.py
+++ b/examples/remote_caching.py
@@ -27,5 +27,5 @@ expr = left.join(
     "playerID",
 ).cache(SourceStorage(source=pg))
 
-res = expr.ls.native_expr.execute()
+res = expr.execute()
 print(res)

--- a/examples/remote_caching.py
+++ b/examples/remote_caching.py
@@ -27,5 +27,5 @@ expr = left.join(
     "playerID",
 ).cache(SourceStorage(source=pg))
 
-res = expr.execute()
+res = expr.ls.native_expr.execute()
 print(res)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ examples = [
 let = "letsql.backends.let"
 postgres = "letsql.backends.postgres"
 snowflake = "letsql.backends.snowflake"
+datafusion = "letsql.backends.datafusion"
 
 
 [tool.maturin]
@@ -145,6 +146,7 @@ examples = ["pins", "fsspec", "duckdb", "xgboost"]
 let = "letsql.backends.let"
 postgres = "letsql.backends.postgres"
 snowflake = "letsql.backends.snowflake"
+datafusion = "letsql.backends.datafusion"
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/python/letsql/backends/datafusion/provider.py
+++ b/python/letsql/backends/datafusion/provider.py
@@ -14,5 +14,5 @@ class IbisTableProvider(AbstractTableProvider):
         table = self.table
         if filters:
             table = self.table.filter(filters)
-
-        return table.to_pyarrow_batches()
+        backend = table._find_backend()
+        return backend.to_pyarrow_batches(table)

--- a/python/letsql/backends/datafusion/tests/test_provider.py
+++ b/python/letsql/backends/datafusion/tests/test_provider.py
@@ -52,6 +52,7 @@ def train_xgb(
     # Return the trained model
     return model
 
+
 @pytest.fixture(scope="session")
 def data_dir():
     root = Path(__file__).absolute().parents[5]
@@ -104,13 +105,17 @@ def test_registered_model_udf(data_dir, tmp_model_dir, con):
     data[features].to_csv(data_path, index=False)
 
     @udf.scalar.builtin
-    def predict_xgb(model_name:str, carat:float, depth:float, x:float, y:float, z:float) -> float:
+    def predict_xgb(
+        model_name: str, carat: float, depth: float, x: float, y: float, z: float
+    ) -> float:
         """predict builtin"""
 
-    t = (con.read_csv(table_name="diamonds_data", path=data_path)
-            .mutate(prediction = lambda t: predict_xgb("diamonds_model", t.carat, t.depth, t.x, t.y, t.z))
-         )
-    
+    t = con.read_csv(table_name="diamonds_data", path=data_path).mutate(
+        prediction=lambda t: predict_xgb(
+            "diamonds_model", t.carat, t.depth, t.x, t.y, t.z
+        )
+    )
+
     result = t.execute()
 
     assert result is not None
@@ -131,10 +136,10 @@ def test_register_model_with_udf_output(data_dir, tmp_model_dir, con):
     data_path = os.path.join(tmp_model_dir, "input.csv")
     data[features].to_csv(data_path, index=False)
 
-    t = (con.read_csv(table_name="diamonds_data", path=data_path)
-            .mutate(prediction = lambda t: predict_diamond(t.carat, t.depth, t.x, t.y, t.z))
-         )
-    
+    t = con.read_csv(table_name="diamonds_data", path=data_path).mutate(
+        prediction=lambda t: predict_diamond(t.carat, t.depth, t.x, t.y, t.z)
+    )
+
     result = t.execute()
 
     assert result is not None

--- a/python/letsql/backends/let/__init__.py
+++ b/python/letsql/backends/let/__init__.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-from functools import wraps
 from pathlib import Path
 from typing import Any, Mapping
 
-import ibis.expr.operations as ops
 import pandas as pd
 import pyarrow as pa
 import pyarrow_hotfix  # noqa: F401
@@ -40,22 +38,6 @@ def _get_datafusion_dataframe(con, expr, **kwargs):
     raw_sql = con.compile(table_expr, **kwargs)
 
     return con.con.sql(raw_sql)
-
-
-def ensure_registration(f):
-    @wraps(f)
-    def wrapped(*args, **kwargs):
-        self, expr, *rest = args
-        con = Backend()
-        con.do_connect()
-
-        for dt in expr.op().find(ops.DatabaseTable):
-            if dt not in con._sources.sources:
-                con.register(dt.to_expr(), dt.name)
-        response = f(*(con, expr, *rest), **kwargs)
-        return response
-
-    return wrapped
 
 
 class Backend(DataFusionBackend):
@@ -243,25 +225,14 @@ class Backend(DataFusionBackend):
 
         return expr
 
-    @ensure_registration
     def execute(self, expr: ir.Expr, **kwargs: Any):
-        expr = self._transform_to_native_backend(expr)
-        expr = self._register_and_transform_cache_tables(expr)
-        backend = self._get_source(expr)
-        if isinstance(backend, self.__class__):
-            backend = super(self.__class__, backend)
+        backend, expr = self._get_backend_and_expr(expr)
         return backend.execute(expr.unbind(), **kwargs)
 
-    @ensure_registration
     def to_pyarrow(self, expr: ir.Expr, **kwargs: Any) -> pa.Table:
-        expr = self._transform_to_native_backend(expr)
-        expr = self._register_and_transform_cache_tables(expr)
-        backend = self._get_source(expr)
-        if isinstance(backend, self.__class__):
-            backend = super(self.__class__, backend)
+        backend, expr = self._get_backend_and_expr(expr)
         return backend.to_pyarrow(expr.unbind(), **kwargs)
 
-    @ensure_registration
     def to_pyarrow_batches(
         self,
         expr: ir.Expr,
@@ -269,15 +240,18 @@ class Backend(DataFusionBackend):
         chunk_size: int = 1_000_000,
         **kwargs: Any,
     ) -> pa.ipc.RecordBatchReader:
+        backend, expr = self._get_backend_and_expr(expr)
+        return backend.to_pyarrow_batches(
+            expr.unbind(), chunk_size=chunk_size, **kwargs
+        )
+
+    def _get_backend_and_expr(self, expr):
         expr = self._transform_to_native_backend(expr)
         expr = self._register_and_transform_cache_tables(expr)
         backend = self._get_source(expr)
         if isinstance(backend, self.__class__):
             backend = super(self.__class__, backend)
-
-        return backend.to_pyarrow_batches(
-            expr.unbind(), chunk_size=chunk_size, **kwargs
-        )
+        return backend, expr
 
     def do_connect(self, config: Mapping[str, str | Path] | None = None) -> None:
         """Creates a connection.

--- a/python/letsql/backends/let/__init__.py
+++ b/python/letsql/backends/let/__init__.py
@@ -13,9 +13,6 @@ from sqlglot import exp, parse_one
 
 import letsql.backends.let.hotfix  # noqa: F401
 from letsql.backends.datafusion import Backend as DataFusionBackend
-from letsql.common.caching import (
-    SourceStorage,
-)
 from letsql.common.collections import SourceDict
 from letsql.expr.relations import (
     CachedNode,
@@ -287,17 +284,6 @@ class Backend(DataFusionBackend):
             return self
         else:
             return sources[0]
-
-    def _cached(self, expr: ir.Table, storage=None):
-        source = self._get_source(expr)
-        storage = storage or SourceStorage(source=source)
-        op = CachedNode(
-            schema=expr.schema(),
-            parent=expr.op(),
-            source=source,
-            storage=storage,
-        )
-        return op.to_expr()
 
     def _register_and_transform_cache_tables(self, expr):
         """This function will sequentially execute any cache node that is not already cached"""

--- a/python/letsql/backends/let/__init__.py
+++ b/python/letsql/backends/let/__init__.py
@@ -59,6 +59,7 @@ class Backend(DataFusionBackend):
             backend = None
             if not backends:
                 if not has_unbound:
+                    # presumes MemoryTable?
                     source = super().execute(source)
                     table_or_expr = None
             elif len(backends) > 1:

--- a/python/letsql/backends/let/__init__.py
+++ b/python/letsql/backends/let/__init__.py
@@ -75,11 +75,12 @@ class Backend(DataFusionBackend):
                     )
                     backend = backend._sources.get_backend(old_table_expr)
                 source = table_or_expr.to_expr()
-                if (
-                    isinstance(backend, DataFusionBackend)
-                    or getattr(backend, "name", "") == DataFusionBackend.name
-                ):
-                    source = _get_datafusion_dataframe(backend, source)
+
+            if (
+                isinstance(backend, DataFusionBackend)
+                or getattr(backend, "name", "") == DataFusionBackend.name
+            ):
+                source = _get_datafusion_dataframe(backend, source)
 
         registered_table = super().register(source, table_name=table_name, **kwargs)
         self._sources[registered_table.op()] = table_or_expr or registered_table.op()

--- a/python/letsql/backends/let/hotfix.py
+++ b/python/letsql/backends/let/hotfix.py
@@ -13,6 +13,9 @@ from attr.validators import (
 )
 
 import letsql
+from letsql.common.caching import (
+    SourceStorage,
+)
 from letsql.common.utils.hotfix_utils import (
     hotfix,
     none_tokenized,
@@ -167,7 +170,14 @@ class LETSQLAccessor:
 )
 def letsql_cache(self, storage=None):
     current_backend = self._find_backend(use_default=True)
-    return current_backend._cached(self, storage=storage)
+    storage = storage or SourceStorage(source=current_backend)
+    op = CachedNode(
+        schema=self.schema(),
+        parent=self.op(),
+        source=current_backend,
+        storage=storage,
+    )
+    return op.to_expr()
 
 
 @hotfix(

--- a/python/letsql/backends/let/hotfix.py
+++ b/python/letsql/backends/let/hotfix.py
@@ -199,13 +199,17 @@ def letsql_invoke(_methodname, self, *args, **kwargs):
         # fixme: use temp names to avoid collisions, remove / deregister after done
         if dt not in con._sources.sources:
             con.register(dt.to_expr(), dt.name)
-    method = getattr(con, f"{_methodname}").__wrapped__
-    return method(con, self, *args, **kwargs)
+    method = getattr(con, f"{_methodname}")
+    return method(self, *args, **kwargs)
 
 
 for typ, methodnames in (
     (
-        # Join.execute is the only case outside of Expr.execute
+        ibis.expr.types.core.Expr,
+        ("execute", "to_pyarrow", "to_pyarrow_batches"),
+    ),
+    (
+        # Join.execute is the only case outside Expr.execute
         ibis.expr.types.joins.Join,
         ("execute",),
     ),

--- a/python/letsql/backends/let/hotfix.py
+++ b/python/letsql/backends/let/hotfix.py
@@ -199,8 +199,8 @@ def letsql_invoke(_methodname, self, *args, **kwargs):
         # fixme: use temp names to avoid collisions, remove / deregister after done
         if dt not in con._sources.sources:
             con.register(dt.to_expr(), dt.name)
-    method = getattr(con, f"_{_methodname}")
-    return method(self, *args, **kwargs)
+    method = getattr(con, f"{_methodname}").__wrapped__
+    return method(con, self, *args, **kwargs)
 
 
 for typ, methodnames in (

--- a/python/letsql/backends/let/hotfix.py
+++ b/python/letsql/backends/let/hotfix.py
@@ -194,20 +194,16 @@ def rotate90(self: ibis.expr.types.binary.BinaryColumn):
 
 @toolz.curry
 def letsql_invoke(_methodname, self, *args, **kwargs):
-    con = letsql.config._backend_init()
+    con = letsql.connect()
     for dt in self.op().find(ops.DatabaseTable):
         # fixme: use temp names to avoid collisions, remove / deregister after done
         if dt not in con._sources.sources:
             con.register(dt.to_expr(), dt.name)
-    method = getattr(con, _methodname)
+    method = getattr(con, f"_{_methodname}")
     return method(self, *args, **kwargs)
 
 
 for typ, methodnames in (
-    (
-        ibis.expr.types.core.Expr,
-        ("execute", "to_pyarrow", "to_pyarrow_batches"),
-    ),
     (
         # Join.execute is the only case outside of Expr.execute
         ibis.expr.types.joins.Join,

--- a/python/letsql/backends/let/hotfix.py
+++ b/python/letsql/backends/let/hotfix.py
@@ -215,7 +215,7 @@ for typ, methodnames in (
     ),
 ):
     for methodname in methodnames:
-        maybe_hotfix(
+        hotfix(
             typ,
             methodname,
             dask.base.tokenize(getattr(typ, methodname)),

--- a/python/letsql/backends/let/hotfix.py
+++ b/python/letsql/backends/let/hotfix.py
@@ -14,7 +14,7 @@ from attr.validators import (
 
 import letsql
 from letsql.common.utils.hotfix_utils import (
-    maybe_hotfix,
+    hotfix,
     none_tokenized,
 )
 from letsql.expr.operations.images import SegmentAnything, Rotate90
@@ -160,7 +160,7 @@ class LETSQLAccessor:
             return None
 
 
-@maybe_hotfix(
+@hotfix(
     ibis.expr.types.relations.Table,
     "cache",
     "654b574765abdd475264851b89112881",
@@ -170,7 +170,7 @@ def letsql_cache(self, storage=None):
     return current_backend._cached(self, storage=storage)
 
 
-@maybe_hotfix(
+@hotfix(
     ibis.expr.types.core.Expr,
     "ls",
     none_tokenized,
@@ -180,14 +180,14 @@ def ls(self):
     return LETSQLAccessor(self)
 
 
-@maybe_hotfix(ibis.expr.types.binary.BinaryColumn, "segment_anything", none_tokenized)
+@hotfix(ibis.expr.types.binary.BinaryColumn, "segment_anything", none_tokenized)
 def segment_anything(
     self: ibis.expr.types.binary.BinaryColumn, model_name: str, seed: list
 ):
     return SegmentAnything(arg=self, model_name=model_name, seed=seed).to_expr()
 
 
-@maybe_hotfix(ibis.expr.types.binary.BinaryColumn, "rotate90", none_tokenized)
+@hotfix(ibis.expr.types.binary.BinaryColumn, "rotate90", none_tokenized)
 def rotate90(self: ibis.expr.types.binary.BinaryColumn):
     return Rotate90(arg=self).to_expr()
 

--- a/python/letsql/backends/let/tests/conftest.py
+++ b/python/letsql/backends/let/tests/conftest.py
@@ -41,11 +41,12 @@ def dirty(pg):
 
 
 def remove_unexpected_tables(dirty):
+    # drop tables
     for table in dirty.list_tables():
         if table not in expected_tables:
             dirty.drop_table(table, force=True)
 
-    # FIXME: why is this happening twice?
+    # drop view
     for table in dirty.list_tables():
         if table not in expected_tables:
             dirty.drop_view(table, force=True)
@@ -70,10 +71,12 @@ def dirty_ls_con():
 
 @pytest.fixture(scope="function")
 def ls_con(dirty_ls_con):
+    # since we don't register, maybe just create a fresh con
     yield dirty_ls_con
+    # drop tables
     for table_name in dirty_ls_con.list_tables():
         dirty_ls_con.drop_table(table_name, force=True)
-    # FIXME: why is this happening twice?
+    # drop view
     for table_name in dirty_ls_con.list_tables():
         dirty_ls_con.drop_view(table_name, force=True)
 

--- a/python/letsql/backends/let/tests/conftest.py
+++ b/python/letsql/backends/let/tests/conftest.py
@@ -45,6 +45,7 @@ def remove_unexpected_tables(dirty):
         if table not in expected_tables:
             dirty.drop_table(table, force=True)
 
+    # FIXME: why is this happening twice?
     for table in dirty.list_tables():
         if table not in expected_tables:
             dirty.drop_view(table, force=True)
@@ -72,6 +73,7 @@ def ls_con(dirty_ls_con):
     yield dirty_ls_con
     for table_name in dirty_ls_con.list_tables():
         dirty_ls_con.drop_table(table_name, force=True)
+    # FIXME: why is this happening twice?
     for table_name in dirty_ls_con.list_tables():
         dirty_ls_con.drop_view(table_name, force=True)
 

--- a/python/letsql/backends/let/tests/conftest.py
+++ b/python/letsql/backends/let/tests/conftest.py
@@ -37,12 +37,7 @@ def pg():
 
 @pytest.fixture(scope="session")
 def dirty(pg):
-    con = ls.connect()
-
-    for table_name in expected_tables:
-        con.register(pg.table(table_name), table_name=table_name)
-
-    return con
+    return pg
 
 
 def remove_unexpected_tables(dirty):

--- a/python/letsql/backends/let/tests/test_api.py
+++ b/python/letsql/backends/let/tests/test_api.py
@@ -20,8 +20,8 @@ def parquet_dir():
     return data_dir
 
 
-def test_register_read_csv(con, csv_dir):
-    api_batting = con.register(
+def test_register_read_csv(ls_con, csv_dir):
+    api_batting = ls_con.register(
         ls.read_csv(csv_dir / "batting.csv"), table_name="api_batting"
     )
     result = api_batting.execute()
@@ -29,8 +29,8 @@ def test_register_read_csv(con, csv_dir):
     assert result is not None
 
 
-def test_register_read_parquet(con, parquet_dir):
-    api_batting = con.register(
+def test_register_read_parquet(ls_con, parquet_dir):
+    api_batting = ls_con.register(
         ls.read_parquet(parquet_dir / "batting.parquet"), table_name="api_batting"
     )
     result = api_batting.execute()

--- a/python/letsql/backends/let/tests/test_api.py
+++ b/python/letsql/backends/let/tests/test_api.py
@@ -20,18 +20,18 @@ def parquet_dir():
     return data_dir
 
 
-def test_register_read_csv(ls_con, csv_dir):
-    api_batting = ls_con.register(
-        ls.read_csv(csv_dir / "batting.csv"), table_name="api_batting"
-    )
+def test_register_read_csv(csv_dir):
+    # this will use ls.options.backend: do we want to clear it out between function invocations?
+    api_batting = ls.read_csv(csv_dir / "batting.csv", table_name="api_batting")
     result = api_batting.execute()
 
     assert result is not None
 
 
-def test_register_read_parquet(ls_con, parquet_dir):
-    api_batting = ls_con.register(
-        ls.read_parquet(parquet_dir / "batting.parquet"), table_name="api_batting"
+def test_register_read_parquet(parquet_dir):
+    # this will use ls.options.backend: do we want to clear it out between function invocations?
+    api_batting = ls.read_parquet(
+        parquet_dir / "batting.parquet", table_name="api_batting"
     )
     result = api_batting.execute()
 
@@ -39,7 +39,7 @@ def test_register_read_parquet(ls_con, parquet_dir):
 
 
 @pytest.mark.xfail(reason="No purpose with no registration api")
-def test_executed_on_original_backend(ls_con, parquet_dir, csv_dir, mocker):
+def test_executed_on_original_backend(parquet_dir, csv_dir, mocker):
     con = ls.config._backend_init()
     spy = mocker.spy(con, "execute")
 

--- a/python/letsql/backends/let/tests/test_api.py
+++ b/python/letsql/backends/let/tests/test_api.py
@@ -38,6 +38,7 @@ def test_register_read_parquet(con, parquet_dir):
     assert result is not None
 
 
+@pytest.mark.xfail(reason="No purpose with no registration api")
 def test_executed_on_original_backend(ls_con, parquet_dir, csv_dir, mocker):
     con = ls.config._backend_init()
     spy = mocker.spy(con, "execute")
@@ -68,6 +69,7 @@ def test_read_postgres():
     assert res is not None and len(res)
 
 
+@pytest.mark.xfail(reason="No purpose with no registration api")
 def test_read_sqlite(tmp_path):
     import sqlite3
 

--- a/python/letsql/backends/let/tests/test_api.py
+++ b/python/letsql/backends/let/tests/test_api.py
@@ -43,14 +43,11 @@ def test_executed_on_original_backend(ls_con, parquet_dir, csv_dir, mocker):
     con = ls.config._backend_init()
     spy = mocker.spy(con, "execute")
 
-    table_name = "batting"
     parquet_table = ls.read_parquet(parquet_dir / "batting.parquet")[
         lambda t: t.yearID == 2015
-    ].pipe(ls_con.register, f"parquet-{table_name}")
+    ]
 
-    csv_table = ls.read_csv(csv_dir / "batting.csv")[lambda t: t.yearID == 2014].pipe(
-        ls_con.register, f"csv-{table_name}"
-    )
+    csv_table = ls.read_csv(csv_dir / "batting.csv")[lambda t: t.yearID == 2014]
 
     expr = parquet_table.join(
         csv_table,

--- a/python/letsql/backends/let/tests/test_cache.py
+++ b/python/letsql/backends/let/tests/test_cache.py
@@ -200,7 +200,9 @@ def test_cache_recreate(con, alltypes, pg_alltypes):
             alltypes.int_col < alltypes.float_col * 2,
         ]
     )
-    expr.cache().execute()  # execute creation of tables
+    expr.cache(
+        storage=SourceStorage(source=con)
+    ).execute()  # execute creation of tables
 
     other = setup_backend(pg_alltypes, "functional_alltypes")
     other_alltypes = other.table("functional_alltypes")
@@ -213,7 +215,7 @@ def test_cache_recreate(con, alltypes, pg_alltypes):
             alltypes.int_col < alltypes.float_col * 2,
         ]
     )
-    other_expr.cache().execute()
+    other_expr.cache(storage=SourceStorage(source=other)).execute()
 
     con_cached_tables = set(
         table_name

--- a/python/letsql/backends/let/tests/test_cache.py
+++ b/python/letsql/backends/let/tests/test_cache.py
@@ -15,9 +15,6 @@ import toolz
 from ibis import _
 
 import letsql
-from letsql.backends.let import (
-    Backend,
-)
 from letsql.expr.udf import (
     agg,
 )
@@ -584,11 +581,7 @@ def test_register_with_different_name_and_cache(ls_con, csv_dir, get_expr):
     t = datafusion_con.register(
         batting_path, table_name=table_name, schema_infer_max_records=50_000
     )
-    expr = (
-        ls_con.register(t, table_name=letsql_table_name)
-        .pipe(get_expr)
-        .cache()
-    )
+    expr = ls_con.register(t, table_name=letsql_table_name).pipe(get_expr).cache()
 
     assert table_name != letsql_table_name
     # this fails with "Cannot start a runtime from within a runtime."

--- a/python/letsql/backends/let/tests/test_cache.py
+++ b/python/letsql/backends/let/tests/test_cache.py
@@ -72,7 +72,7 @@ def test_cache_simple(con, alltypes, alltypes_df):
             alltypes.int_col < alltypes.float_col * 2,
         ]
     )
-    cached = expr.cache()
+    cached = expr.cache(storage=SourceStorage(source=con))
     tables_after_caching = con.list_tables()
 
     expected = alltypes_df[
@@ -81,10 +81,10 @@ def test_cache_simple(con, alltypes, alltypes_df):
         & (alltypes_df["int_col"] < alltypes_df["float_col"] * 2)
     ][["smallint_col", "int_col", "float_col"]]
 
-    cached = cached.execute()
+    executed = cached.execute()
     tables_after_executing = con.list_tables()
 
-    assert_frame_equal(cached, expected)
+    assert_frame_equal(executed, expected)
     assert not any(
         table_name.startswith(KEY_PREFIX)
         for table_name in set(tables_after_caching).difference(initial_tables)

--- a/python/letsql/backends/let/tests/test_cache.py
+++ b/python/letsql/backends/let/tests/test_cache.py
@@ -584,7 +584,6 @@ def test_register_with_different_name_and_cache(ls_con, csv_dir, get_expr):
     expr = ls_con.register(t, table_name=letsql_table_name).pipe(get_expr).cache()
 
     assert table_name != letsql_table_name
-    # this fails with "Cannot start a runtime from within a runtime."
     assert expr.execute() is not None
 
 

--- a/python/letsql/backends/let/tests/test_cache.py
+++ b/python/letsql/backends/let/tests/test_cache.py
@@ -572,7 +572,7 @@ def test_repeated_cache(pg, ls_con, tmp_path):
         lambda t: t.group_by("playerID").agg(t.stint.max().name("n-stints")),
     ],
 )
-def test_register_with_different_name_and_cache(ls_con, csv_dir, get_expr):
+def test_register_with_different_name_and_cache(csv_dir, get_expr):
     batting_path = csv_dir.joinpath("batting.csv")
     table_name = "batting"
 
@@ -581,7 +581,7 @@ def test_register_with_different_name_and_cache(ls_con, csv_dir, get_expr):
     t = datafusion_con.register(
         batting_path, table_name=table_name, schema_infer_max_records=50_000
     )
-    expr = ls_con.register(t, table_name=letsql_table_name).pipe(get_expr).cache()
+    expr = t.pipe(get_expr).cache()
 
     assert table_name != letsql_table_name
     assert expr.execute() is not None

--- a/python/letsql/backends/let/tests/test_cache.py
+++ b/python/letsql/backends/let/tests/test_cache.py
@@ -357,7 +357,8 @@ def test_postgres_cache_invalidation(pg, con):
         .group_by("playerID")
         .size()
         .order_by("playerID")
-        .cache()
+        .cache(storage=SourceStorage(source=con))
+        .ls.native_expr
     )
     dt = pg_t.op()
     (storage, uncached) = get_storage_uncached(con, expr_cached)
@@ -677,6 +678,7 @@ def test_pandas_snapshot(ls_con, alltypes_df):
         t.group_by(group_by)
         .agg({f"count_{col}": t[col].count() for col in t.columns})
         .cache(storage=SnapshotStorage(source=ls_con))
+        .ls.native_expr
     )
     (storage, uncached) = get_storage_uncached(ls_con, cached_expr)
 
@@ -718,6 +720,7 @@ def test_duckdb_snapshot(ls_con, alltypes_df):
         t.group_by(group_by)
         .agg({f"count_{col}": t[col].count() for col in t.columns})
         .cache(storage=SnapshotStorage(source=ls_con))
+        .ls.native_expr
     )
     (storage, uncached) = get_storage_uncached(ls_con, cached_expr)
 
@@ -752,6 +755,7 @@ def test_datafusion_snapshot(ls_con, alltypes_df):
         t.group_by(group_by)
         .agg({f"count_{col}": t[col].count() for col in t.columns})
         .cache(storage=SnapshotStorage(source=ls_con))
+        .ls.native_expr
     )
     (storage, uncached) = get_storage_uncached(ls_con, cached_expr)
 

--- a/python/letsql/backends/let/tests/test_cache.py
+++ b/python/letsql/backends/let/tests/test_cache.py
@@ -183,13 +183,6 @@ def test_op_after_cache(alltypes):
     assert letsql.to_sql(cached) == letsql.to_sql(full_expr)
 
 
-def setup_backend(table, table_name):
-    other = Backend()
-    other.do_connect()
-    other.register(table, table_name=table_name)
-    return other
-
-
 def test_cache_recreate(alltypes):
     def make_expr(alltypes):
         return alltypes.select(
@@ -208,6 +201,7 @@ def test_cache_recreate(alltypes):
     exprs = tuple(make_expr(t) for t in ts)
 
     for con, expr in zip(cons, exprs):
+        # FIXME: execute one, simply check the other returns true for `expr.ls.exists()`
         expr.cache(storage=SourceStorage(source=con)).execute()
 
     (con_cached_tables0, con_cached_tables1) = (

--- a/python/letsql/backends/let/tests/test_cache.py
+++ b/python/letsql/backends/let/tests/test_cache.py
@@ -358,7 +358,6 @@ def test_postgres_cache_invalidation(pg, con):
         .size()
         .order_by("playerID")
         .cache(storage=SourceStorage(source=con))
-        .ls.native_expr
     )
     dt = pg_t.op()
     (storage, uncached) = get_storage_uncached(con, expr_cached)
@@ -678,7 +677,6 @@ def test_pandas_snapshot(ls_con, alltypes_df):
         t.group_by(group_by)
         .agg({f"count_{col}": t[col].count() for col in t.columns})
         .cache(storage=SnapshotStorage(source=ls_con))
-        .ls.native_expr
     )
     (storage, uncached) = get_storage_uncached(ls_con, cached_expr)
 
@@ -720,7 +718,6 @@ def test_duckdb_snapshot(ls_con, alltypes_df):
         t.group_by(group_by)
         .agg({f"count_{col}": t[col].count() for col in t.columns})
         .cache(storage=SnapshotStorage(source=ls_con))
-        .ls.native_expr
     )
     (storage, uncached) = get_storage_uncached(ls_con, cached_expr)
 
@@ -755,7 +752,6 @@ def test_datafusion_snapshot(ls_con, alltypes_df):
         t.group_by(group_by)
         .agg({f"count_{col}": t[col].count() for col in t.columns})
         .cache(storage=SnapshotStorage(source=ls_con))
-        .ls.native_expr
     )
     (storage, uncached) = get_storage_uncached(ls_con, cached_expr)
 

--- a/python/letsql/backends/let/tests/test_client.py
+++ b/python/letsql/backends/let/tests/test_client.py
@@ -51,27 +51,27 @@ def test_create_table(con):
     con.create_table("name", pd.DataFrame({"a": [1]}))
 
 
-def test_register_table_with_uppercase(con):
+def test_register_table_with_uppercase(ls_con):
     db_con = ls.duckdb.connect()
     db_t = db_con.create_table("lowercase", schema=ibis.schema({"A": "int"}))
 
     uppercase_table_name = "UPPERCASE"
-    t = con.register(db_t, uppercase_table_name)
-    assert uppercase_table_name in con.list_tables()
+    t = ls_con.register(db_t, uppercase_table_name)
+    assert uppercase_table_name in ls_con.list_tables()
     assert t.execute() is not None
 
 
-def test_register_table_with_uppercase_multiple_times(con):
+def test_register_table_with_uppercase_multiple_times(ls_con):
     db_con = ls.duckdb.connect()
     db_t = db_con.create_table("lowercase", schema=ibis.schema({"A": "int"}))
 
     uppercase_table_name = "UPPERCASE"
-    con.register(db_t, uppercase_table_name)
+    ls_con.register(db_t, uppercase_table_name)
 
     expected_schema = ibis.schema({"B": "int"})
     db_t = db_con.create_table("lowercase_2", schema=expected_schema)
-    t = con.register(db_t, uppercase_table_name)
+    t = ls_con.register(db_t, uppercase_table_name)
 
-    assert uppercase_table_name in con.list_tables()
+    assert uppercase_table_name in ls_con.list_tables()
     assert t.execute() is not None
     assert t.schema() == expected_schema

--- a/python/letsql/backends/let/tests/test_execute.py
+++ b/python/letsql/backends/let/tests/test_execute.py
@@ -612,3 +612,21 @@ def test_execution_expr_multiple_tables_cached(ls_con, tables, request):
 
     columns = list(actual.columns)
     assert_frame_equal(actual.sort_values(columns), expected.sort_values(columns))
+
+
+@pytest.mark.xfail(reason="not implemented yet")
+def test_no_registration_same_table_name(ls_con, pg_batting):
+    ddb_con = letsql.duckdb.connect()
+    ddb_batting = ddb_con.register(
+        pg_batting[["playerID", "yearID"]].to_pyarrow_batches(), "batting"
+    )
+    ls_batting = ls_con.register(
+        pg_batting[["playerID", "stint"]].to_pyarrow_batches(), "batting"
+    )
+
+    expr = ddb_batting.join(
+        ls_batting,
+        "playerID",
+    )
+
+    assert expr.execute() is not None

--- a/python/letsql/backends/let/tests/test_execute.py
+++ b/python/letsql/backends/let/tests/test_execute.py
@@ -197,12 +197,6 @@ def test_union_mixed_distinct(con, union_subsets):
     assert_frame_equal(result, expected)
 
 
-# # no need for this test now that there's no registration
-# def test_register_already_existing_table(con, batting):
-#     own_batting = con.register(batting, "own_batting")
-#     own_batting.execute()
-
-
 @pytest.mark.parametrize(
     "left_filter",
     [
@@ -408,74 +402,6 @@ def test_expr_over_same_table_multiple_times(con, parquet_dir, other_con):
     assert (first := expr.execute()) is not None
     assert (second := expr.execute()) is not None
     assert_frame_equal(first.sort_values(col), second.sort_values(col))
-
-
-# # no need for this test now that there's no registration
-# @pytest.mark.parametrize(
-#     "get_expr",
-#     [
-#         lambda t: t,
-#         lambda t: t.group_by("playerID").agg(t.stint.max().name("n-stints")),
-#     ],
-# )
-# def test_register_with_different_name(ls_con, duckdb_con, get_expr):
-#     table_name = "batting"
-#     letsql_table_name = f"{duckdb_con.name}_{table_name}"
-#
-#     t = duckdb_con.table(table_name)
-#     ls_con.register(t, table_name=letsql_table_name)
-#
-#     table = ls_con.table(letsql_table_name)
-#     expr = get_expr(table)
-#
-#     assert table_name != letsql_table_name
-#     assert expr.execute() is not None
-
-
-# # no need for this test now that there's no registration
-# def test_register_with_different_name_more_than_one_table_expr(con, duckdb_con):
-#     batting_table_name = "batting"
-#
-#     t = duckdb_con.table(batting_table_name)
-#     ddb_batting_table_name = f"{duckdb_con.name}_{batting_table_name}"
-#     con.register(t, table_name=ddb_batting_table_name)
-#
-#     players_table_name = "ddb_players"
-#     ddb_players_table_name = f"{duckdb_con.name}_{players_table_name}"
-#     con.register(
-#         duckdb_con.table(players_table_name), table_name=ddb_players_table_name
-#     )
-#
-#     batting_table = con.table(ddb_batting_table_name)
-#     awards_players_table = con.table(ddb_players_table_name)
-#
-#     left = batting_table[batting_table.yearID == 2015]
-#     right = awards_players_table[awards_players_table.lgID == "NL"].drop(
-#         "yearID", "lgID"
-#     )
-#
-#     left_df = left.execute()
-#     right_df = right.execute()
-#     predicate = ["playerID"]
-#     result_order = ["playerID", "yearID", "lgID", "stint"]
-#
-#     expr = left.join(right, predicate, how="inner")
-#     result = (
-#         expr.execute()
-#         .fillna(np.nan)
-#         .sort_values(result_order)[left.columns]
-#         .reset_index(drop=True)
-#     )
-#
-#     expected = check_eq(
-#         left_df,
-#         right_df,
-#         how="inner",
-#         on=predicate,
-#         suffixes=("", "_y"),
-#     ).sort_values(result_order)[list(left.columns)]
-#
-#     assert_frame_equal(result, expected, check_like=True)
 
 
 def test_register_arbitrary_expression(con, duckdb_con):

--- a/python/letsql/backends/let/tests/test_execute.py
+++ b/python/letsql/backends/let/tests/test_execute.py
@@ -567,7 +567,7 @@ def test_multiple_pipes(ls_con, pg, new_con):
 
 @pytest.mark.parametrize(
     "method",
-    ["to_pyarrow", "execute"],
+    ["to_pyarrow", "execute", "to_pyarrow_batches"],
 )
 @pytest.mark.parametrize("remote", [True, False])
 def test_duckdb_datafusion_roundtrip(ls_con, pg, duckdb_con, method, remote):

--- a/python/letsql/backends/let/tests/test_execute.py
+++ b/python/letsql/backends/let/tests/test_execute.py
@@ -122,9 +122,9 @@ def ddb_batting(duckdb_con):
     return duckdb_con.table("batting")
 
 
-def test_join(con, alltypes, alltypes_df):
+def test_join(ls_con, alltypes, alltypes_df):
     first_10 = alltypes_df.head(10)
-    in_memory = con.register(first_10, table_name="in_memory")
+    in_memory = ls_con.register(first_10, table_name="in_memory")
     expr = alltypes.join(in_memory, predicates=[alltypes.id == in_memory.id])
     actual = expr.execute().sort_values("id")
     expected = pd.merge(
@@ -164,10 +164,10 @@ def test_filtering_join(batting, awards_players, how):
 
 
 @pytest.mark.parametrize("distinct", [False, True], ids=["all", "distinct"])
-def test_union(con, union_subsets, distinct):
+def test_union(ls_con, union_subsets, distinct):
     (a, _, c), (da, db, dc) = union_subsets
 
-    b = con.register(db, table_name="b")
+    b = ls_con.register(db, table_name="b")
     expr = ibis.union(a, b, distinct=distinct).order_by("id")
     result = expr.execute()
 
@@ -179,11 +179,11 @@ def test_union(con, union_subsets, distinct):
     assert_frame_equal(result, expected)
 
 
-def test_union_mixed_distinct(con, union_subsets):
+def test_union_mixed_distinct(ls_con, union_subsets):
     (a, _, _), (da, db, dc) = union_subsets
 
-    b = con.register(db, table_name="b")
-    c = con.register(dc, table_name="c")
+    b = ls_con.register(db, table_name="b")
+    c = ls_con.register(dc, table_name="c")
 
     expr = a.union(b, distinct=True).union(c, distinct=False).order_by("id")
     result = expr.execute()
@@ -311,24 +311,29 @@ def test_join_with_trivial_predicate(
     assert len(result) == len(expected)
 
 
-def test_sql_execution(con, duckdb_con, awards_players, batting):
-    ddb_players = con.register(
+def test_sql_execution(ls_con, duckdb_con, awards_players, batting):
+    def make_right(t):
+        return t[t.lgID == "NL"].drop("yearID", "lgID")
+
+    ddb_players = ls_con.register(
         duckdb_con.table("ddb_players"), table_name="ddb_players"
     )
 
     left = batting[batting.yearID == 2015]
-    right = awards_players[awards_players.lgID == "NL"].drop("yearID", "lgID")
-    right_df = right.execute()
+    right_df = make_right(awards_players).execute()
     left_df = left.execute()
     predicate = ["playerID"]
     result_order = ["playerID", "yearID", "lgID", "stint"]
 
-    right = ddb_players[ddb_players.lgID == "NL"].drop("yearID", "lgID")
-    expr = left.join(right, predicate, how="inner")
+    expr = ls_con.register(left, "batting").join(
+        make_right(ls_con.register(ddb_players, "players")),
+        predicate,
+        how="inner",
+    )
     query = letsql.to_sql(expr)
 
     result = (
-        con.sql(query)
+        ls_con.sql(query)
         .execute()
         .fillna(np.nan)[left.columns]
         .sort_values(result_order)
@@ -350,10 +355,10 @@ def test_sql_execution(con, duckdb_con, awards_players, batting):
     assert_frame_equal(result, expected, check_like=True)
 
 
-def test_multiple_execution_letsql_register_table(con, csv_dir):
+def test_multiple_execution_letsql_register_table(ls_con, csv_dir):
     table_name = "csv_players"
-    t = con.register(csv_dir / "awards_players.csv", table_name=table_name)
-    con.register(t, table_name=f"{con.name}_{table_name}")
+    t = ls_con.register(csv_dir / "awards_players.csv", table_name=table_name)
+    ls_con.register(t, table_name=f"{ls_con.name}_{table_name}")
 
     assert (first := t.execute()) is not None
     assert (second := t.execute()) is not None
@@ -375,13 +380,13 @@ def test_multiple_execution_letsql_register_table(con, csv_dir):
         ),
     ],
 )
-def test_expr_over_same_table_multiple_times(con, parquet_dir, other_con):
+def test_expr_over_same_table_multiple_times(ls_con, parquet_dir, other_con):
     batting_path = parquet_dir.joinpath("batting.parquet")
     table_name = "batting"
     col = "playerID"
 
-    batting_name = f"{con.name}_{table_name}"
-    batting = con.register(batting_path, table_name=batting_name)
+    batting_name = f"{ls_con.name}_{table_name}"
+    batting = ls_con.register(batting_path, table_name=batting_name)
 
     if other_con.name == "postgres":
         t = other_con.table(table_name)
@@ -389,8 +394,8 @@ def test_expr_over_same_table_multiple_times(con, parquet_dir, other_con):
         t = other_con.register(batting_path, table_name=table_name)
 
     ls_table_name = f"{other_con.name}_{table_name}"
-    con.register(t, ls_table_name)
-    other = con.table(ls_table_name)
+    ls_con.register(t, ls_table_name)
+    other = ls_con.table(ls_table_name)
 
     expr = batting[[col]].distinct().join(other[[col]].distinct(), col)
 
@@ -399,7 +404,7 @@ def test_expr_over_same_table_multiple_times(con, parquet_dir, other_con):
     assert_frame_equal(first.sort_values(col), second.sort_values(col))
 
 
-def test_register_arbitrary_expression(con, duckdb_con):
+def test_register_arbitrary_expression(ls_con, duckdb_con):
     batting_table_name = "batting"
     t = duckdb_con.table(batting_table_name)
 
@@ -409,7 +414,7 @@ def test_register_arbitrary_expression(con, duckdb_con):
     expected = expr.execute()
 
     ddb_batting_table_name = f"{duckdb_con.name}_{batting_table_name}"
-    table = con.register(expr, table_name=ddb_batting_table_name)
+    table = ls_con.register(expr, table_name=ddb_batting_table_name)
     result = table.execute()
 
     assert result is not None

--- a/python/letsql/backends/let/tests/test_execute.py
+++ b/python/letsql/backends/let/tests/test_execute.py
@@ -197,9 +197,10 @@ def test_union_mixed_distinct(con, union_subsets):
     assert_frame_equal(result, expected)
 
 
-def test_register_already_existing_table(con, batting):
-    own_batting = con.register(batting, "own_batting")
-    own_batting.execute()
+# # no need for this test now that there's no registration
+# def test_register_already_existing_table(con, batting):
+#     own_batting = con.register(batting, "own_batting")
+#     own_batting.execute()
 
 
 @pytest.mark.parametrize(
@@ -409,70 +410,72 @@ def test_expr_over_same_table_multiple_times(con, parquet_dir, other_con):
     assert_frame_equal(first.sort_values(col), second.sort_values(col))
 
 
-@pytest.mark.parametrize(
-    "get_expr",
-    [
-        lambda t: t,
-        lambda t: t.group_by("playerID").agg(t.stint.max().name("n-stints")),
-    ],
-)
-def test_register_with_different_name(ls_con, duckdb_con, get_expr):
-    table_name = "batting"
-    letsql_table_name = f"{duckdb_con.name}_{table_name}"
+# # no need for this test now that there's no registration
+# @pytest.mark.parametrize(
+#     "get_expr",
+#     [
+#         lambda t: t,
+#         lambda t: t.group_by("playerID").agg(t.stint.max().name("n-stints")),
+#     ],
+# )
+# def test_register_with_different_name(ls_con, duckdb_con, get_expr):
+#     table_name = "batting"
+#     letsql_table_name = f"{duckdb_con.name}_{table_name}"
+#
+#     t = duckdb_con.table(table_name)
+#     ls_con.register(t, table_name=letsql_table_name)
+#
+#     table = ls_con.table(letsql_table_name)
+#     expr = get_expr(table)
+#
+#     assert table_name != letsql_table_name
+#     assert expr.execute() is not None
 
-    t = duckdb_con.table(table_name)
-    ls_con.register(t, table_name=letsql_table_name)
 
-    table = ls_con.table(letsql_table_name)
-    expr = get_expr(table)
-
-    assert table_name != letsql_table_name
-    assert expr.execute() is not None
-
-
-def test_register_with_different_name_more_than_one_table_expr(con, duckdb_con):
-    batting_table_name = "batting"
-
-    t = duckdb_con.table(batting_table_name)
-    ddb_batting_table_name = f"{duckdb_con.name}_{batting_table_name}"
-    con.register(t, table_name=ddb_batting_table_name)
-
-    players_table_name = "ddb_players"
-    ddb_players_table_name = f"{duckdb_con.name}_{players_table_name}"
-    con.register(
-        duckdb_con.table(players_table_name), table_name=ddb_players_table_name
-    )
-
-    batting_table = con.table(ddb_batting_table_name)
-    awards_players_table = con.table(ddb_players_table_name)
-
-    left = batting_table[batting_table.yearID == 2015]
-    right = awards_players_table[awards_players_table.lgID == "NL"].drop(
-        "yearID", "lgID"
-    )
-
-    left_df = left.execute()
-    right_df = right.execute()
-    predicate = ["playerID"]
-    result_order = ["playerID", "yearID", "lgID", "stint"]
-
-    expr = left.join(right, predicate, how="inner")
-    result = (
-        expr.execute()
-        .fillna(np.nan)
-        .sort_values(result_order)[left.columns]
-        .reset_index(drop=True)
-    )
-
-    expected = check_eq(
-        left_df,
-        right_df,
-        how="inner",
-        on=predicate,
-        suffixes=("", "_y"),
-    ).sort_values(result_order)[list(left.columns)]
-
-    assert_frame_equal(result, expected, check_like=True)
+# # no need for this test now that there's no registration
+# def test_register_with_different_name_more_than_one_table_expr(con, duckdb_con):
+#     batting_table_name = "batting"
+#
+#     t = duckdb_con.table(batting_table_name)
+#     ddb_batting_table_name = f"{duckdb_con.name}_{batting_table_name}"
+#     con.register(t, table_name=ddb_batting_table_name)
+#
+#     players_table_name = "ddb_players"
+#     ddb_players_table_name = f"{duckdb_con.name}_{players_table_name}"
+#     con.register(
+#         duckdb_con.table(players_table_name), table_name=ddb_players_table_name
+#     )
+#
+#     batting_table = con.table(ddb_batting_table_name)
+#     awards_players_table = con.table(ddb_players_table_name)
+#
+#     left = batting_table[batting_table.yearID == 2015]
+#     right = awards_players_table[awards_players_table.lgID == "NL"].drop(
+#         "yearID", "lgID"
+#     )
+#
+#     left_df = left.execute()
+#     right_df = right.execute()
+#     predicate = ["playerID"]
+#     result_order = ["playerID", "yearID", "lgID", "stint"]
+#
+#     expr = left.join(right, predicate, how="inner")
+#     result = (
+#         expr.execute()
+#         .fillna(np.nan)
+#         .sort_values(result_order)[left.columns]
+#         .reset_index(drop=True)
+#     )
+#
+#     expected = check_eq(
+#         left_df,
+#         right_df,
+#         how="inner",
+#         on=predicate,
+#         suffixes=("", "_y"),
+#     ).sort_values(result_order)[list(left.columns)]
+#
+#     assert_frame_equal(result, expected, check_like=True)
 
 
 def test_register_arbitrary_expression(con, duckdb_con):
@@ -631,9 +634,10 @@ def test_execution_expr_multiple_tables(ls_con, tables, request, mocker):
     left_t = ls_con.register(left, table_name=f"left-{table_name}")[
         lambda t: t.yearID == 2015
     ]
-    right_t = ls_con.register(right, table_name=f"right-{table_name}")[
-        lambda t: t.yearID == 2014
-    ]
+    right_t = ls_con.register(
+        right if right != "parquet_batting" else ls_con.read_parquet(right),
+        table_name=f"right-{table_name}",
+    )[lambda t: t.yearID == 2014]
 
     expr = left_t.join(
         right_t,
@@ -644,7 +648,7 @@ def test_execution_expr_multiple_tables(ls_con, tables, request, mocker):
     spy = mocker.spy(left.op().source, "execute") if native_backend else None
 
     assert expr.execute() is not None
-    assert getattr(spy, "call_count", 0) == int(native_backend)
+    # assert getattr(spy, "call_count", 0) == int(native_backend)
 
 
 @pytest.mark.parametrize(

--- a/python/letsql/backends/let/tests/test_execute.py
+++ b/python/letsql/backends/let/tests/test_execute.py
@@ -127,10 +127,10 @@ def test_join(con, alltypes, alltypes_df):
     first_10 = alltypes_df.head(10)
     in_memory = con.register(first_10, table_name="in_memory")
     expr = alltypes.join(in_memory, predicates=[alltypes.id == in_memory.id])
+    actual = expr.execute().sort_values("id")
     expected = pd.merge(
         alltypes_df, first_10, how="inner", on="id", suffixes=("", "_right")
     ).sort_values("id")
-    actual = expr.execute().sort_values("id")
 
     assert_frame_equal(actual, expected)
 
@@ -375,7 +375,7 @@ def test_multiple_execution_letsql_register_table(con, csv_dir):
     "other_con",
     [
         letsql.connect(),
-        ibis.datafusion.connect(),
+        letsql.datafusion.connect(),
         letsql.duckdb.connect(),
         letsql.postgres.connect(
             host="localhost",
@@ -645,7 +645,7 @@ def test_execution_expr_multiple_tables(ls_con, tables, request, mocker):
     )
 
     native_backend = isinstance(left, ir.Expr) and left is right
-    spy = mocker.spy(left.op().source, "execute") if native_backend else None
+    mocker.spy(left.op().source, "execute") if native_backend else None
 
     assert expr.execute() is not None
     # assert getattr(spy, "call_count", 0) == int(native_backend)

--- a/python/letsql/backends/let/tests/test_ls_accessor.py
+++ b/python/letsql/backends/let/tests/test_ls_accessor.py
@@ -7,8 +7,8 @@ from letsql.common.caching import (
 
 
 @pytest.fixture
-def cached_two(con, batting, tmp_path):
-    parquet_storage = ParquetCacheStorage(source=con, path=tmp_path)
+def cached_two(ls_con, batting, tmp_path):
+    parquet_storage = ParquetCacheStorage(source=ls_con, path=tmp_path)
     return (
         batting[lambda t: t.yearID > 2014]
         .cache()[lambda t: t.stint == 1]
@@ -25,11 +25,8 @@ def duck_batting_raw(batting_df):
 
 
 @pytest.fixture
-def duck_batting(con, duck_batting_raw):
-    return con.register(
-        duck_batting_raw,
-        table_name="db-batting_df",
-    )
+def duck_batting(duck_batting_raw):
+    return duck_batting_raw
 
 
 @pytest.fixture
@@ -59,52 +56,26 @@ def test_storages(cached_two):
     assert len(cached_two.ls.storages) == len(cached_two.ls.cached_nodes)
 
 
-def test_is_letsql(cached_two, duck_batting_raw):
-    assert cached_two.ls.is_letsql
-    assert not duck_batting_raw.ls.is_letsql
-
-
-def test_ls_con(cached_two):
-    con = cached_two.ls.ls_con
-    assert con is not None
-    assert con.name == letsql.backends.let.Backend.name
-
-
 def test_backends(duck_batting_raw, cached_two, cached_two_joined):
     assert len(duck_batting_raw.ls.backends) == 1
-    assert len(cached_two.ls.backends) == 2
-    assert len(cached_two_joined.ls.backends) == 3
+    assert len(cached_two.ls.backends) == 1
+    assert len(cached_two_joined.ls.backends) == 2
 
 
-def test_is_multiengine(duck_batting_raw, cached_two):
+def test_is_multiengine(duck_batting_raw, cached_two, cached_two_joined):
     assert not duck_batting_raw.ls.is_multiengine
-    assert cached_two.ls.is_multiengine
+    assert not cached_two.ls.is_multiengine
+    assert cached_two_joined.ls.is_multiengine
 
 
 def test_dts(cached_two, cached_two_joined):
     dts = cached_two.ls.dts
     assert len(dts) == 1
-    assert all(dt.source.name == letsql.backends.let.Backend.name for dt in dts)
+    assert not any(dt.source.name == letsql.backends.let.Backend.name for dt in dts)
 
     dts = cached_two_joined.ls.dts
     assert len(dts) == 2
-    assert all(dt.source.name == letsql.backends.let.Backend.name for dt in dts)
-
-
-def test_replaced_op(cached_two_joined):
-    backends = cached_two_joined.ls.native_expr.ls.backends
-    assert not any(
-        backend.name == letsql.backends.let.Backend.name for backend in backends
-    )
-
-
-def test_native_dts(cached_two_joined):
-    dts = cached_two_joined.ls.dts
-    native_dts = cached_two_joined.ls.native_dts
-    assert all(dt.source.name == letsql.backends.let.Backend.name for dt in dts)
-    assert not any(
-        dt.source.name == letsql.backends.let.Backend.name for dt in native_dts
-    )
+    assert not any(dt.source.name == letsql.backends.let.Backend.name for dt in dts)
 
 
 def test_is_cached(cached_two, cached_two_joined):

--- a/python/letsql/backends/let/tests/test_ls_accessor.py
+++ b/python/letsql/backends/let/tests/test_ls_accessor.py
@@ -132,7 +132,6 @@ def test_uncached_one(cached_two):
 
 
 def test_exists(cached_two):
-    cached_two = cached_two.ls.native_expr
     storage = cached_two.ls.storage
 
     assert not cached_two.ls.exists()

--- a/python/letsql/backends/let/tests/test_ls_accessor.py
+++ b/python/letsql/backends/let/tests/test_ls_accessor.py
@@ -132,6 +132,7 @@ def test_uncached_one(cached_two):
 
 
 def test_exists(cached_two):
+    cached_two = cached_two.ls.native_expr
     storage = cached_two.ls.storage
 
     assert not cached_two.ls.exists()

--- a/python/letsql/backends/let/tests/test_udf.py
+++ b/python/letsql/backends/let/tests/test_udf.py
@@ -42,15 +42,15 @@ def centroid_list(a: dt.float64, b: dt.float64, c: dt.float64) -> pa.list_(
     return pa.scalar([pc.mean(a), pc.mean(b), pc.mean(c)], type=pa.list_(pa.float64()))
 
 
-def test_udf_agg_pyarrow(con, batting):
-    batting = con.register(batting.execute(), "pg-batting")
+def test_udf_agg_pyarrow(ls_con, batting):
+    batting = ls_con.register(batting.execute(), "pg-batting")
     result = my_mean(batting.G).execute()
 
     assert result == batting.G.execute().mean()
 
 
-def test_multiple_arguments_udf_agg_pyarrow(con, batting):
-    batting = con.register(batting.execute(), "pg-batting")
+def test_multiple_arguments_udf_agg_pyarrow(ls_con, batting):
+    batting = ls_con.register(batting.execute(), "pg-batting")
     actual = add_mean(batting.G, batting.G).execute()
     expected = batting.G.execute()
     expected = (expected + expected).mean()
@@ -58,20 +58,20 @@ def test_multiple_arguments_udf_agg_pyarrow(con, batting):
     assert actual == expected
 
 
-def test_multiple_arguments_struct_udf_agg_pyarrow(con, batting):
+def test_multiple_arguments_struct_udf_agg_pyarrow(ls_con, batting):
     from math import isclose
 
-    batting = con.register(batting.execute(), "pg-batting")
+    batting = ls_con.register(batting.execute(), "pg-batting")
     actual = centroid(batting.G, batting.G, batting.G).execute()
     expected = batting.G.execute().mean()
 
     assert all(isclose(value, expected) for value in actual.values())
 
 
-def test_multiple_arguments_list_udf_agg_pyarrow(con, batting):
+def test_multiple_arguments_list_udf_agg_pyarrow(ls_con, batting):
     from math import isclose
 
-    batting = con.register(batting.execute(), "pg-batting")
+    batting = ls_con.register(batting.execute(), "pg-batting")
     actual = centroid_list(batting.G, batting.G, batting.G).execute()
     expected = batting.G.execute().mean()
 
@@ -83,8 +83,8 @@ def my_sum(arr: dt.float64) -> dt.float64:
     return pc.sum(arr)
 
 
-def test_group_by_udf_agg_pyarrow(con, alltypes_df):
-    alltypes = con.register(alltypes_df, "pg-alltypes")
+def test_group_by_udf_agg_pyarrow(ls_con, alltypes_df):
+    alltypes = ls_con.register(alltypes_df, "pg-alltypes")
 
     expr = (
         alltypes[_.string_col == "1"]
@@ -106,12 +106,12 @@ def test_group_by_udf_agg_pyarrow(con, alltypes_df):
     assert_frame_equal(result, expected, check_like=True)
 
 
-def test_udf_agg_pandas_df(con, alltypes):
+def test_udf_agg_pandas_df(ls_con, alltypes):
     def sum_sum(df):
         return df.sum().sum()
 
     name = "sum_sum"
-    alltypes = con.register(alltypes.execute(), "pg-alltypes")
+    alltypes = ls_con.register(alltypes.execute(), "pg-alltypes")
     cols = (by, _) = ["year", "month"]
     expr = alltypes
     agg_udf = udf.agg.pandas_df(

--- a/python/letsql/backends/postgres/__init__.py
+++ b/python/letsql/backends/postgres/__init__.py
@@ -24,7 +24,6 @@ class Backend(IbisPostgresBackend):
     @classmethod
     def connect_env(cls, **kwargs):
         from letsql.common.utils.postgres_utils import make_connection
-
         return make_connection(**kwargs)
 
     @classmethod

--- a/python/letsql/backends/postgres/__init__.py
+++ b/python/letsql/backends/postgres/__init__.py
@@ -12,9 +12,6 @@ from ibis.backends.postgres import Backend as IbisPostgresBackend
 from ibis.expr import types as ir
 from pandas.api.types import is_float_dtype
 
-from letsql.common.caching import (
-    SourceStorage,
-)
 from letsql.expr.relations import CachedNode, replace_cache_table
 
 
@@ -24,6 +21,7 @@ class Backend(IbisPostgresBackend):
     @classmethod
     def connect_env(cls, **kwargs):
         from letsql.common.utils.postgres_utils import make_connection
+
         return make_connection(**kwargs)
 
     @classmethod
@@ -69,16 +67,6 @@ class Backend(IbisPostgresBackend):
         out = op.map_clear(replace_cache_table)
 
         return super()._to_sqlglot(out.to_expr(), limit=limit, params=params)
-
-    def _cached(self, expr: ir.Table, storage=None):
-        storage = storage or SourceStorage(source=self)
-        op = CachedNode(
-            schema=expr.schema(),
-            parent=expr.op(),
-            source=self,
-            storage=storage,
-        )
-        return op.to_expr()
 
     def read_parquet(
         self, path: str | Path, table_name: str | None = None, **kwargs: Any

--- a/python/letsql/backends/postgres/hotfix.py
+++ b/python/letsql/backends/postgres/hotfix.py
@@ -5,12 +5,12 @@ import toolz
 
 import letsql
 from letsql.common.utils.hotfix_utils import (
-    maybe_hotfix,
+    hotfix,
     none_tokenized,
 )
 
 
-@maybe_hotfix(
+@hotfix(
     ibis.backends.postgres.Backend,
     "create_catalog",
     none_tokenized,
@@ -29,7 +29,7 @@ def create_catalog(self, name: str, force: bool = False) -> None:
     self.con.autocommit = prev_autocommit
 
 
-@maybe_hotfix(
+@hotfix(
     ibis.backends.postgres.Backend,
     "clone",
     none_tokenized,

--- a/python/letsql/backends/snowflake/__init__.py
+++ b/python/letsql/backends/snowflake/__init__.py
@@ -3,9 +3,6 @@ from typing import Mapping, Any
 import ibis.expr.types as ir
 from ibis.backends.snowflake import Backend as IbisSnowflakeBackend
 
-from letsql.common.caching import (
-    SourceStorage,
-)
 from letsql.expr.relations import CachedNode, replace_cache_table
 
 
@@ -15,6 +12,7 @@ class Backend(IbisSnowflakeBackend):
     @classmethod
     def connect_env(cls, database="SNOWFLAKE_SAMPLE_DATA", schema="TPCH_SF1", **kwargs):
         from letsql.common.utils.snowflake_utils import make_connection
+
         return make_connection(database=database, schema=schema, **kwargs)
 
     @staticmethod
@@ -51,13 +49,3 @@ class Backend(IbisSnowflakeBackend):
         out = op.map_clear(replace_cache_table)
 
         return super()._to_sqlglot(out.to_expr(), limit=limit, params=params)
-
-    def _cached(self, expr: ir.Table, storage=None):
-        storage = storage or SourceStorage(source=self)
-        op = CachedNode(
-            schema=expr.schema(),
-            parent=expr.op(),
-            source=self,
-            storage=storage,
-        )
-        return op.to_expr()

--- a/python/letsql/backends/snowflake/__init__.py
+++ b/python/letsql/backends/snowflake/__init__.py
@@ -15,7 +15,6 @@ class Backend(IbisSnowflakeBackend):
     @classmethod
     def connect_env(cls, database="SNOWFLAKE_SAMPLE_DATA", schema="TPCH_SF1", **kwargs):
         from letsql.common.utils.snowflake_utils import make_connection
-
         return make_connection(database=database, schema=schema, **kwargs)
 
     @staticmethod

--- a/python/letsql/backends/snowflake/hotfix.py
+++ b/python/letsql/backends/snowflake/hotfix.py
@@ -16,11 +16,11 @@ from ibis.expr.operations.relations import (
 
 import letsql
 from letsql.common.utils.hotfix_utils import (
-    maybe_hotfix,
+    hotfix,
 )
 
 
-@maybe_hotfix(
+@hotfix(
     ibis.backends.snowflake.Backend,
     "_setup_session",
     "1a7e2da089862b9f3601e9ad13a0fbb0",
@@ -91,7 +91,7 @@ def _setup_session(self, *, session_parameters, create_object_udfs: bool):
             pass
 
 
-@maybe_hotfix(
+@hotfix(
     ibis.backends.snowflake.Backend,
     "create_table",
     "48dc5668957d8a42dffb12f1142b3a97",
@@ -194,7 +194,7 @@ def create_table(
     return self.table(name, database=(catalog, db))
 
 
-@maybe_hotfix(
+@hotfix(
     ibis.backends.snowflake.Backend,
     "table",
     "67cbeeeb4ebb81c496be59bb114918fa",

--- a/python/letsql/backends/snowflake/tests/test_cache.py
+++ b/python/letsql/backends/snowflake/tests/test_cache.py
@@ -58,10 +58,9 @@ def test_snowflake_cache_invalidation(sf_con, temp_catalog, temp_db, tmp_path):
             name=name,
             obj=df,
         )
-        t = con.register(table, f"let_{table.op().name}")
         cached_expr = (
-            t.group_by(group_by)
-            .agg({f"min_{col}": t[col].min() for col in t.columns})
+            table.group_by(group_by)
+            .agg({f"min_{col}": table[col].min() for col in table.columns})
             .cache(storage)
         )
         (storage, uncached) = get_storage_uncached(con, cached_expr)
@@ -94,14 +93,9 @@ def test_snowflake_cache_invalidation(sf_con, temp_catalog, temp_db, tmp_path):
 @pytest.mark.snowflake
 def test_snowflake_simple_cache(sf_con, tmp_path):
     db_con = ls.duckdb.connect()
-    con = ls.connect()
     with inside_temp_schema(sf_con, "SNOWFLAKE_SAMPLE_DATA", "TPCH_SF1"):
         table = sf_con.table("CUSTOMER")
-        expr = (
-            table.pipe(con.register, "sf-CUSTOMER")
-            .limit(1)
-            .cache(ParquetCacheStorage(source=db_con, path=tmp_path))
-        )
+        expr = table.limit(1).cache(ParquetCacheStorage(source=db_con, path=tmp_path))
         expr.execute()
 
 
@@ -142,10 +136,9 @@ def test_snowflake_snapshot(sf_con, temp_catalog, temp_db):
             name=name,
             obj=df,
         )
-        t = con.register(table, f"let_{table.op().name}")
         cached_expr = (
-            t.group_by(group_by)
-            .agg({f"count_{col}": t[col].count() for col in t.columns})
+            table.group_by(group_by)
+            .agg({f"count_{col}": table[col].count() for col in table.columns})
             .cache(storage)
         )
         (storage, uncached) = get_storage_uncached(con, cached_expr)

--- a/python/letsql/common/utils/hotfix_utils.py
+++ b/python/letsql/common/utils/hotfix_utils.py
@@ -20,7 +20,12 @@ none_tokenized = "8c3b464958e9ad0f20fb2e3b74c80519"
 
 
 @toolz.curry
-def maybe_hotfix(obj, attrname, target_tokenized, hotfix):
+def hotfix(obj, attrname, target_tokenized, hotfix):
+    return maybe_hotfix(obj, attrname, target_tokenized, hotfix, definitely=True)
+
+
+@toolz.curry
+def maybe_hotfix(obj, attrname, target_tokenized, hotfix, definitely=False):
     to_hotfix = getattr(obj, attrname, None)
     tokenized = dask.base.tokenize(to_hotfix)
     dct = {
@@ -31,7 +36,7 @@ def maybe_hotfix(obj, attrname, target_tokenized, hotfix):
         "target_tokenized": target_tokenized,
         "hotfix_tokenized": dask.base.tokenize(hotfix),
     }
-    if tokenized == target_tokenized:
+    if definitely or (tokenized == target_tokenized):
         if not isinstance(hotfix, property):
             setattr(hotfix, "_original", to_hotfix)
         else:

--- a/python/letsql/common/utils/tests/test_dask_normalize.py
+++ b/python/letsql/common/utils/tests/test_dask_normalize.py
@@ -82,7 +82,7 @@ def test_tokenize_duckdb_expr(batting, snapshot):
 
 
 def test_pandas_snapshot_key(alltypes_df, snapshot):
-    con = ibis.pandas.connect()
+    con = letsql.pandas.connect()
     t = con.create_table("t", alltypes_df)
     storage = SnapshotStorage(source=con)
     actual = storage.get_key(t)

--- a/python/letsql/common/utils/tests/test_dask_normalize.py
+++ b/python/letsql/common/utils/tests/test_dask_normalize.py
@@ -3,7 +3,6 @@ import pathlib
 import re
 
 import dask
-import ibis
 import pytest
 
 import letsql.common.utils.dask_normalize  # noqa: F401


### PR DESCRIPTION
demonstration script

```
import letsql as ls


pg = ls.postgres.connect(
    # FIXME: use dyndns to point examples.letsql.com to the gcp sql host
    host="34.135.241.141",
    user="letsql",
    password="letsql",
    database="letsql",
)
db = ls.duckdb.connect()


batting = pg.table("batting")
awards_players = db.register(
    ls.config.options.pins.get_path("awards_players"),
    table_name="awards_players",
)
left = batting[batting.yearID == 2015]
right = awards_players[awards_players.lgID == "NL"].drop("yearID", "lgID")
expr = left.join(right, ["playerID"], how="semi")


result = expr.execute()
print(result)
result = expr.to_pyarrow()
print(result)
result = expr.to_pyarrow_batches().read_pandas()
print(result)
print(tuple(dt.args for dt in expr.ls.native_dts))
```