### PR TITLE
chore: use postgres.connect_examples() and TemporaryDirectory

### DIFF
--- a/examples/postgres_caching.py
+++ b/examples/postgres_caching.py
@@ -1,17 +1,8 @@
 import letsql as ls
 from letsql import _
 from letsql.common.caching import ParquetCacheStorage
-from letsql.common.utils.postgres_utils import (
-    make_connection,
-)
 
-pg = make_connection(
-    host="localhost",
-    port=5432,
-    user="postgres",
-    password="postgres",
-    database="ibis_testing",
-)
+pg = ls.postgres.connect_examples()
 
 for table_name in pg.list_tables():
     if table_name.startswith(ls.config.options.cache.key_prefix):

--- a/examples/predict_xgb.py
+++ b/examples/predict_xgb.py
@@ -1,3 +1,5 @@
+import tempfile
+
 import letsql as ls
 from letsql.common.caching import ParquetCacheStorage
 
@@ -5,19 +7,13 @@ from letsql.common.caching import ParquetCacheStorage
 model_name = "diamonds-model"
 model_path = ls.options.pins.get_path(model_name)
 
+# change tmp_dir to the desired directory
+with tempfile.TemporaryDirectory() as tmp_dir:
+    con = ls.connect()
+    predict_xgb = con.register_xgb_model(model_name, model_path)
+    cache = ParquetCacheStorage(source=con, path=tmp_dir)
+    pg = ls.postgres.connect_examples()
+    t = pg.table("diamonds").pipe(con.register, "diamonds").cache(storage=cache)
 
-con = ls.connect()
-predict_xgb = con.register_xgb_model(model_name, model_path)
-cache = ParquetCacheStorage(source=con, path="letsql-tmp")
-pg = ls.postgres.connect(
-    # FIXME: use dyndns to point examples.letsql.com to the gcp sql host
-    host="34.135.241.141",
-    user="letsql",
-    password="letsql",
-    database="letsql",
-)
-t = pg.table("diamonds").pipe(con.register, "diamonds").cache(storage=cache)
-
-
-output = t.mutate(prediction=predict_xgb.on_expr).execute()
-output
+    output = t.mutate(prediction=predict_xgb.on_expr).execute()
+    print(output)


### PR DESCRIPTION
Executing the examples creates a letsql-tmp directory, that makes into the changes on git. Use a TemporaryDirectory instead