### PR TITLE
chore: add workflow for testing library only dependencies

### DIFF
--- a/.github/workflows/ci-docs-main.yml
+++ b/.github/workflows/ci-docs-main.yml
@@ -50,7 +50,7 @@ jobs:
           version: 1.4.515
 
       - name: maturin develop
-        run: poetry run maturin develop
+        run: poetry run maturin develop --release
         working-directory: ${{ github.workspace }}
 
       - name: start services

--- a/.github/workflows/ci-docs-preview.yml
+++ b/.github/workflows/ci-docs-preview.yml
@@ -57,7 +57,7 @@ jobs:
           version: 1.4.515
 
       - name: maturin develop
-        run: poetry run maturin develop
+        run: poetry run maturin develop --release
         working-directory: ${{ github.workspace }}
 
       - name: start services

--- a/.github/workflows/ci-test-library.yml
+++ b/.github/workflows/ci-test-library.yml
@@ -1,4 +1,4 @@
-name: ci-test
+name: ci-test-library
 
 on:
   push:
@@ -27,16 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [x86_64, x86, aarch64]
-        python-version: ["3.10", "3.11"]
+        target: ["x86_64"]
+        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: download test data
-        run: just download-data
 
       - name: Rust latest
         run: rustup update
@@ -45,21 +42,13 @@ jobs:
         uses: snok/install-poetry@v1
 
       - name: Poetry install
-        run: poetry install --with="dev,test" --extras="duckdb snowflake datafusion examples"
+        run: poetry install
         working-directory: ${{ github.workspace }}
 
       - name: maturin develop
         run: poetry run maturin develop --release
         working-directory: ${{ github.workspace }}
 
-      - name: start services
-        run: docker compose up --build --wait
-
       - name: poetry pytest
-        run: poetry run pytest --import-mode=importlib --cov --cov-report=xml
+        run: poetry run pytest --import-mode=importlib python/letsql/tests/test_examples.py -v -m library
         working-directory: ${{ github.workspace }}
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.5.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ filterwarnings = [
 ]
 markers = [
     "snowflake",
+    "library"
 ]
 
 

--- a/python/letsql/tests/test_examples.py
+++ b/python/letsql/tests/test_examples.py
@@ -25,8 +25,16 @@ def teardown_function():
         path.unlink(missing_ok=True)
 
 
+def maybe_library(name: str):
+    return pytest.mark.library if name == "pandas_example" else ()
+
+
 @pytest.mark.parametrize(
-    "script", [param(script, id=script.stem) for script in scripts]
+    "script",
+    [
+        param(script, id=script.stem, marks=maybe_library(script.stem))
+        for script in scripts
+    ],
 )
 def test_script_execution(script):
     runpy.run_path(str(script))


### PR DESCRIPTION
The `extras` and `dev,test` dependencies add additional dependencies that may not be present with a library install 
(`pip install letsql`).

This commit aims to add a workflow for testing the library only using the specified dependencies (not including the one in the examples extra).

Additionally, it adds `--release` to the poetry maturin build to speed up the tests.