### PR TITLE
chore: fix pre-release workflow

### DIFF
--- a/.github/workflows/ci-pre-release.yml
+++ b/.github/workflows/ci-pre-release.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
+        target: [x86_64, x86, aarch64]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -35,7 +35,7 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter
           sccache: 'true'
-          manylinux: auto
+          manylinux: ${{ matrix.target == 'aarch64' && '2_28' || 'auto' }}
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
+        target: [x86_64, x86, aarch64]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -37,7 +37,7 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter
           sccache: 'true'
-          manylinux: auto
+          manylinux: ${{ matrix.target == 'aarch64' && '2_28' || 'auto' }}
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
**What?**
The workflow was failing at the build stage for the Linux arch aarch64

**Why?**
The reason was the new Cargo dependencies for reading a csv from http(s)/s3. In particular, the `ring` transitive dependency: https://crates.io/crates/ring

**Solution:**
The solution is to drop the architectures armv7, s390x, and ppc64le, which Datafusion or Polars do not support.

Switch the manylinux to `2_28` when the architecture is aarch64 as suggested by:

https://github.com/briansmith/ring/issues/1728#issuecomment-1758180655

Datafusion also implemented this change.

https://github.com/apache/datafusion-python/blob/fe0738a9c0b536cdf20b0dc0455d14a0d16d2835/.github/workflows/build.yml#L218-L219