### PR TITLE
fix(nix): enable build on linux

### DIFF
--- a/nix/letsql.nix
+++ b/nix/letsql.nix
@@ -50,6 +50,7 @@ let
       nativeBuildInputs = [
         python
         pkgs.pkg-config
+      ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
         pkgs.darwin.apple_sdk.frameworks.Security
       ];
       buildInputs = pkgs.lib.optionals pkgs.stdenv.isDarwin [


### PR DESCRIPTION
restore working nix build on linux by making `Security` an `isDarwin` optional