### PR TITLE
feat: add pipe operator

### DIFF
--- a/python/letsql/pipe/README.md
+++ b/python/letsql/pipe/README.md
@@ -67,7 +67,7 @@ multiple partial expressions in one large pipeline, for example:
     )
 ```
 
-Notice the use of each `|` pipe to "glue" together each partial expression.
+Notice the use of each `|` pipe to "glue" together each partial expression, it should be used for that. 
 
 ### Proposal: Pipe Operator should receive multiple arguments
 

--- a/python/letsql/pipe/README.md
+++ b/python/letsql/pipe/README.md
@@ -1,0 +1,96 @@
+## Pipe Module
+
+The pipe module introduces 3 changes to LETSQL, with the objective of letting users of the library
+to quickly build data pipelines. These changes are:
+
+- Partial Ibis Expressions
+- Pipe Operator
+- Workflow Tools Module
+
+### Partial Ibis Expressions
+
+The Partial Ibis Expressions allows the user to create functions that receive a table to apply transformations 
+on that table, the transformations can be:
+
+1. join
+2. mutate
+3. select
+4. filter
+5. head
+
+This simplifies the creation of the steps or tasks of a pipeline, for example something like:
+
+```python
+@task
+def load(table):
+    pipeline = (
+        table.join(right, "a")
+        .select("a", bx="b", cx="c")
+        .mutate(a2=_.a * 2, bcx=_.bx + _.cx)
+        .limit(5)
+    )
+    return pipeline
+```
+
+becomes:
+
+```python
+load = (
+    join(right, "a")
+    .select("a", bx="b", cx="c")
+    .mutate(a2=_.a * 2, bcx=_.bx + _.cx)
+    .limit(5)
+)
+```
+
+#### Proposal: Pipe Method for Partial Ibis Expressions
+
+Perhaps is worthy to add a pipe method to `PartialExpr` class, similar to the one in `ibis` but with the 
+added benefit of receiving multiple functions instead of single one.
+
+### Pipe Operator 
+
+The objective of the pipe `|` operator is to be able to "glue" together multiple functions, including ibis partial 
+expressions. The semantics is similar to the `pipe` function from `ibis`, it will compose two functions together over
+an `ibis` table. 
+
+By using the pipe operator we simplify the construction of data pipelines, because it enables the user to pipe together
+multiple partial expressions in one large pipeline, for example:
+
+```python
+    pipeline = (
+        left
+        | join(right, "a")
+        | select("a", bx="b", cx="c")
+        | mutate(a2=_.a * 2, bcx=_.bx + _.cx)
+        | limit(5)
+    )
+```
+
+Notice the use of each `|` pipe to "glue" together each partial expression.
+
+### Proposal: Pipe Operator should receive multiple arguments
+
+A nice syntactic sugar would be to let the `|` receive multiple arguments, for example:
+
+```python
+    pipeline = (
+        [left, right]
+        | join("a")
+        | select("a", bx="b", cx="c")
+        | mutate(a2=_.a * 2, bcx=_.bx + _.cx)
+        | limit(5)
+    )
+```
+
+### Workflow Tools Module
+
+The workflow tools module should include functions to manipulate and execute a data pipeline:
+
+- execute: executes the workflow using a local engine (such as DuckDB, or DataFusion)
+- [proposal] tee: writes the pyarrow_batches of an expr to multiple outputs returns the expr bound to the last connection
+- [proposal] read: read an `ibis.Table` from a file or a connection
+- [proposal] write: write to a file or to a connection
+- [proposal] cache: caches an expr to a particular connection or file, can be thought of as write followed by a read.
+- [proposal] redirect: it will be like the ">" operator
+

--- a/python/letsql/pipe/ibis/__init__.py
+++ b/python/letsql/pipe/ibis/__init__.py
@@ -3,6 +3,8 @@ from typing import Callable
 
 import ibis as ix
 
+import pyarrow as pa
+
 
 def compose(func, other, *args, **keywords):
     def composition(self, *a, **kw):
@@ -63,6 +65,12 @@ class PartialExpr:
         return PartialExpr(bound)
 
     def __ror__(self, value):
+        if isinstance(value, pa.RecordBatchReader):
+            backend = ix.get_backend()
+            value = backend.read_in_memory(
+                value
+            )  # TODO: ix.memtable does not work for record batch reader
+
         return self.func(value)
 
 

--- a/python/letsql/pipe/ibis/__init__.py
+++ b/python/letsql/pipe/ibis/__init__.py
@@ -1,0 +1,77 @@
+from functools import update_wrapper
+from typing import Callable
+
+import ibis as ix
+
+
+def compose(func, other, *args, **keywords):
+    def composition(self, *a, **kw):
+        return other(func(self, *a, **kw), *args, **keywords)
+
+    return composition
+
+
+class PartialExpr:
+    def __init__(self, func: Callable):
+        update_wrapper(self, func)
+        self.func = func
+
+    def _compose(self, other, *args, **kwargs):
+        return PartialExpr(compose(self.func, other, *args, **kwargs))
+
+    def limit(self, n: int | None, offset: int = 0) -> "PartialExpr":
+        return self._compose(ix.Table.limit, n, offset)
+
+    def join(
+        self,
+        right: ix.Table,
+        predicates=(),
+        how="inner",
+        *,
+        lname: str = "",
+        rname: str = "{name}_right",
+    ) -> "PartialExpr":
+        return self._compose(
+            ix.Table.join,
+            right,
+            predicates=predicates,
+            how=how,
+            lname=lname,
+            rname=rname,
+        )
+
+    def select(
+        self,
+        *exprs,
+        **named_exprs,
+    ) -> "PartialExpr":
+        return self._compose(ix.Table.select, *exprs, **named_exprs)
+
+    def mutate(self, *exprs, **mutations) -> "PartialExpr":
+        return self._compose(ix.Table.mutate, *exprs, **mutations)
+
+    def filter(self, *predicates) -> "PartialExpr":
+        return self._compose(ix.Table.filter, *predicates)
+
+    def head(self, n: int = 5) -> "PartialExpr":
+        return self._compose(ix.Table.head, n)
+
+    def __call__(self, *args, **keywords):
+        def bound(other, *a, **kw):
+            return self.func(other, *args, *a, **keywords, **kw)
+
+        return PartialExpr(bound)
+
+    def __ror__(self, value):
+        return self.func(value)
+
+
+select = PartialExpr(ix.Table.select)
+limit = PartialExpr(ix.Table.limit)
+join = PartialExpr(ix.Table.join)
+mutate = PartialExpr(ix.Table.mutate)
+head = PartialExpr(ix.Table.head)
+filter = PartialExpr(ix.Table.filter)
+sql = PartialExpr(ix.Table.sql)
+
+_ = ix._

--- a/python/letsql/tests/test_pipe.py
+++ b/python/letsql/tests/test_pipe.py
@@ -4,6 +4,23 @@ import pytest
 
 from letsql.pipe.ibis import select, join, limit, mutate, sql, head, _
 
+from pandas.testing import assert_frame_equal
+
+
+def read_csv_with_pandas(path, chunk_size=10_000):
+    import pyarrow as pa
+    from itertools import chain
+
+    chunks = pd.read_csv(path, chunksize=chunk_size)
+
+    batches = map(pa.RecordBatch.from_pandas, chunks)
+    first = next(batches)
+    schema = first.schema
+
+    return pa.RecordBatchReader.from_batches(
+        schema, (chunk for chunk in chain((first,), batches))
+    )
+
 
 @pytest.fixture
 def left():
@@ -24,14 +41,14 @@ def penguins():
 
 def test_select_limit(left):
     pipeline = left | select("a") | limit(5)
-    assert pipeline.execute() is not None
+    assert_frame_equal(pipeline.execute(), left.select("a").limit(5).execute())
 
 
 def test_select_mutate_and_join(left, right):
     pipeline = left | join(right, "a").select("a", bx="b", cx="c").mutate(
         a2=_.a * 2, bcx=_.bx + _.cx
     ).limit(5)
-    assert pipeline.execute() is not None
+    assert isinstance(pipeline.execute(), pd.DataFrame)
 
 
 def test_select_mutate_and_join_with_pipes(left, right):
@@ -42,7 +59,7 @@ def test_select_mutate_and_join_with_pipes(left, right):
         | mutate(a2=_.a * 2, bcx=_.bx + _.cx)
         | limit(5)
     )
-    assert pipeline.execute() is not None
+    assert isinstance(pipeline.execute(), pd.DataFrame)
 
 
 def test_filter(left):
@@ -95,3 +112,14 @@ def test_sql(penguins):
     )
 
     assert pipeline.execute() is not None
+
+
+def test_pandas_read_csv(data_dir):
+    """This test exemplifies some syntactic sugar when building pipelines"""
+    path = data_dir / "csv" / "diamonds.csv"
+    diamonds = read_csv_with_pandas(path)
+    pipeline = diamonds | limit(4)
+    assert pipeline.execute() is not None
+
+
+# TODO: add another example test on how to expand the reading options of the pipe

--- a/python/letsql/tests/test_pipe.py
+++ b/python/letsql/tests/test_pipe.py
@@ -1,0 +1,97 @@
+import ibis
+import pandas as pd
+import pytest
+
+from letsql.pipe.ibis import select, join, limit, mutate, sql, head, _
+
+
+@pytest.fixture
+def left():
+    left = pd.DataFrame({"a": list(range(10)), "b": [f"b_{i}" for i in range(10, 20)]})
+    return ibis.memtable(left, name="left")
+
+
+@pytest.fixture
+def right():
+    right = pd.DataFrame({"a": list(range(10)), "c": [f"c_{i}" for i in range(10, 20)]})
+    return ibis.memtable(right, name="right")
+
+
+@pytest.fixture
+def penguins():
+    return ibis.examples.penguins.fetch(table_name="penguins")
+
+
+def test_select_limit(left):
+    pipeline = left | select("a") | limit(5)
+    assert pipeline.execute() is not None
+
+
+def test_select_mutate_and_join(left, right):
+    pipeline = left | join(right, "a").select("a", bx="b", cx="c").mutate(
+        a2=_.a * 2, bcx=_.bx + _.cx
+    ).limit(5)
+    assert pipeline.execute() is not None
+
+
+def test_select_mutate_and_join_with_pipes(left, right):
+    pipeline = (
+        left
+        | join(right, "a")
+        | select("a", bx="b", cx="c")
+        | mutate(a2=_.a * 2, bcx=_.bx + _.cx)
+        | limit(5)
+    )
+    assert pipeline.execute() is not None
+
+
+def test_filter(left):
+    pipeline = left | select("a").filter(_.a < 5)
+    assert pipeline.execute() is not None
+
+
+def test_head(left):
+    pipeline = left | select("a").head()
+    assert pipeline.execute() is not None
+
+
+def test_limit(left):
+    pipeline = left | select("a").limit(5)
+    assert pipeline.execute() is not None
+
+
+def test_join(left, right):
+    pipeline = left | select("a").join(right, "a")
+    assert pipeline.execute() is not None
+
+
+def test_mutate(left):
+    pipeline = left | mutate(a2=_.a * 2)
+    assert pipeline.execute() is not None
+
+
+def test_mutate_select(left):
+    pipeline = left | mutate(a2=_.a * 2).select("a", "a2")
+    assert pipeline.execute() is not None
+
+
+def test_select_mutate(right):
+    pipeline = right | select("a").mutate(a2=_.a * 2)
+    assert pipeline.execute() is not None
+
+
+def test_sql(penguins):
+    pipeline = (
+        penguins
+        | sql(
+            """
+        SELECT island, mean(bill_length_mm) AS avg_bill_length
+        FROM penguins
+        GROUP BY 1
+        ORDER BY 2 DESC
+        """
+        )
+        | head(4)
+    )
+
+    assert pipeline.execute() is not None


### PR DESCRIPTION
Add the pipe operator with the ability to create partial ibis expressions, for example, with this PR now is possible to do:
```python
pipeline = (
        left
        | join(right, "a")
        | select("a", bx="b", cx="c")
        | mutate(a2=_.a * 2, bcx=_.bx + _.cx)
        | limit(5)
    )
```

as well as (the equivalent):

```python
pipeline = left | join(right, "a").select("a", bx="b", cx="c").mutate(
        a2=_.a * 2, bcx=_.bx + _.cx
    ).limit(5)
```

also the method `sql` is supported:

```python
pipeline = (
        penguins
        | sql(
            """
        SELECT island, mean(bill_length_mm) AS avg_bill_length
        FROM penguins
        GROUP BY 1
        ORDER BY 2 DESC
        """
        )
        | head(4)
    )
```
