### PR TITLE
chore: ci check for right install

### DIFF
--- a/.github/workflows/ci-test-library.yml
+++ b/.github/workflows/ci-test-library.yml
@@ -47,13 +47,19 @@ jobs:
         run: python -m venv .venv
 
       - name: install dependencies
-        run: .venv/bin/python -m pip install pytest maturin
+        run: |
+          source .venv/bin/activate
+          python -m pip install pytest maturin
 
       - name: develop
-        run: .venv/bin/python -m maturin develop
+        run: |
+          source .venv/bin/activate
+          python -m maturin develop
 
       - name: test
-        run: .venv/bin/python -m pytest --import-mode=importlib python/letsql/tests/test_examples.py -v -m library
+        run: |
+          source .venv/bin/activate
+          python -m pytest --import-mode=importlib python/letsql/tests/test_examples.py -v -m library
         working-directory: ${{ github.workspace }}
         env:
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_GH_PASSWORD }}

--- a/.github/workflows/ci-test-library.yml
+++ b/.github/workflows/ci-test-library.yml
@@ -35,20 +35,29 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Rust latest
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: rust latest
         run: rustup update
 
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
+      # check how to use virtual environment https://stackoverflow.com/q/74668349/4001592
+      - name: create virtual environment
+        run: python -m venv .venv
 
-      - name: Poetry install
-        run: poetry install
-        working-directory: ${{ github.workspace }}
+      - name: install dependencies
+        run: .venv/bin/python -m pip install pytest maturin
 
-      - name: maturin develop
-        run: poetry run maturin develop
-        working-directory: ${{ github.workspace }}
+      - name: develop
+        run: .venv/bin/python -m maturin develop
 
-      - name: poetry pytest
-        run: poetry run pytest --import-mode=importlib python/letsql/tests/test_examples.py -v -m library
+      - name: test
+        run: .venv/bin/python -m pytest --import-mode=importlib python/letsql/tests/test_examples.py -v -m library
         working-directory: ${{ github.workspace }}
+        env:
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_GH_PASSWORD }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_GH_USER }}
+          POSTGRES_HOST: ${{ secrets.POSTGRES_GH_HOST }}
+          POSTGRES_PORT: ${{ secrets.POSTGRES_GH_PORT }}
+          POSTGRES_DATABASE: ${{ secrets.POSTGRES_GH_DATABASE }}

--- a/examples/remote_caching.py
+++ b/examples/remote_caching.py
@@ -3,13 +3,7 @@ from letsql.common.caching import SourceStorage
 
 con = ls.connect()
 ddb = ls.duckdb.connect()
-pg = ls.postgres.connect(
-    host="localhost",
-    port=5432,
-    user="postgres",
-    password="postgres",
-    database="ibis_testing",
-)
+pg = ls.postgres.connect_env()
 
 name = "batting"
 path = ls.config.options.pins.get_path(name)


### PR DESCRIPTION
This PR only uses `pip` and `venv` to verify the library is installed correctly. 
1. The first step is to install `pytest` and `maturin`
2. Execute `maturin develop` to install letsql in development mode
3. Execute some of the examples to verify the correct installation 

This will fail if a `dependency` is specified in `poetry` and not in the `dependencies`. 