### PR TITLE
chore: use vars instead of secrets

### DIFF
--- a/.github/workflows/ci-test-examples.yml
+++ b/.github/workflows/ci-test-examples.yml
@@ -64,8 +64,8 @@ jobs:
           python -m pytest --import-mode=importlib python/letsql/tests/test_examples.py -v
         working-directory: ${{ github.workspace }}
         env:
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_GH_PASSWORD }}
-          POSTGRES_USER: ${{ secrets.POSTGRES_GH_USER }}
-          POSTGRES_HOST: ${{ secrets.POSTGRES_GH_HOST }}
-          POSTGRES_PORT: ${{ secrets.POSTGRES_GH_PORT }}
-          POSTGRES_DATABASE: ${{ secrets.POSTGRES_GH_DATABASE }}
+          POSTGRES_PASSWORD: ${{ vars.POSTGRES_PASSWORD }}
+          POSTGRES_USER: ${{ vars.POSTGRES_USER }}
+          POSTGRES_HOST: ${{ vars.POSTGRES_HOST }}
+          POSTGRES_PORT: ${{ vars.POSTGRES_PORT }}
+          POSTGRES_DATABASE: ${{ vars.POSTGRES_DATABASE }}

--- a/.github/workflows/ci-test-library.yml
+++ b/.github/workflows/ci-test-library.yml
@@ -62,8 +62,8 @@ jobs:
           python -m pytest --import-mode=importlib python/letsql/tests/test_examples.py -v -m library
         working-directory: ${{ github.workspace }}
         env:
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_GH_PASSWORD }}
-          POSTGRES_USER: ${{ secrets.POSTGRES_GH_USER }}
-          POSTGRES_HOST: ${{ secrets.POSTGRES_GH_HOST }}
-          POSTGRES_PORT: ${{ secrets.POSTGRES_GH_PORT }}
-          POSTGRES_DATABASE: ${{ secrets.POSTGRES_GH_DATABASE }}
+          POSTGRES_PASSWORD: ${{ vars.POSTGRES_PASSWORD }}
+          POSTGRES_USER: ${{ vars.POSTGRES_USER }}
+          POSTGRES_HOST: ${{ vars.POSTGRES_HOST }}
+          POSTGRES_PORT: ${{ vars.POSTGRES_PORT }}
+          POSTGRES_DATABASE: ${{ vars.POSTGRES_DATABASE }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -59,11 +59,11 @@ jobs:
         run: poetry run pytest --import-mode=importlib --cov --cov-report=xml -k 'not script_execution'
         working-directory: ${{ github.workspace }}
         env:
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_GH_PASSWORD }}
-          POSTGRES_USER: ${{ secrets.POSTGRES_GH_USER }}
-          POSTGRES_HOST: ${{ secrets.POSTGRES_GH_HOST }}
-          POSTGRES_PORT: ${{ secrets.POSTGRES_GH_PORT }}
-          POSTGRES_DATABASE: ${{ secrets.POSTGRES_GH_DATABASE }}
+          POSTGRES_PASSWORD: ${{ vars.POSTGRES_PASSWORD }}
+          POSTGRES_USER: ${{ vars.POSTGRES_USER }}
+          POSTGRES_HOST: ${{ vars.POSTGRES_HOST }}
+          POSTGRES_PORT: ${{ vars.POSTGRES_PORT }}
+          POSTGRES_DATABASE: ${{ vars.POSTGRES_DATABASE }}
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.6.0


### PR DESCRIPTION
PRs from forked repositories cannot access secrets [[1](https://michaelheap.com/access-secrets-from-forks/)]

Currently we are using secrets to store default credentials to access the PostgreSQL Docker instance, since these values are not secrets we should store them in vars, to make them accesible from forked repositories.