### PR TITLE
chore: pin cargo dependencies version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,7 @@
   ],
   "semanticCommits": "enabled",
   "lockFileMaintenance": { "enabled": false },
+  "updateLockFiles": false,
   "enabledManagers": [
     "docker-compose",
     "dockerfile",
@@ -13,6 +14,13 @@
     "pep621",
     "poetry",
     "cargo"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["cargo"],
+      "rangeStrategy": "pin",
+      "automerge": false
+    }
   ],
   "pre-commit": {
     "enabled": false


### PR DESCRIPTION
Since we are using Rust to create Python packages, a particular version of the package is selected at compile time, so we don't need to provide a range of dependencies for Cargo.