### PR TITLE
 Feature implement train test split

### DIFF
--- a/examples/train_test_splits.py
+++ b/examples/train_test_splits.py
@@ -1,0 +1,44 @@
+import letsql as ls
+from letsql import memtable
+
+N = 100000
+# if single float deferred partitions of train and test will be returned
+# With proportions (1-test_size, test_size)
+test_size = 0.25
+# init table
+table = memtable([(i, "val") for i in range(N)], columns=["key1", "val"])
+
+
+train_table, test_table = ls.train_test_splits(
+    table, unique_key="key1", test_sizes=test_size, num_buckets=N, random_seed=42
+)
+
+train_count = train_table.count().execute()
+test_count = test_table.count().execute()
+total = train_count + test_count
+print(f"train ratio: {round(train_count/total,2)}")
+print(f"test ratio: {round(test_count/total,2)}\n")
+
+
+# If test sizes is a list of floats , mutually exclusive partitions will be returned
+partition_info = {
+    "hold_out": 0.1,
+    "test": 0.2,
+    "validation": 0.3,
+    "training": 0.4,
+}
+
+partitions = tuple(
+    ls.train_test_splits(
+        table,
+        unique_key="key1",
+        test_sizes=list(partition_info.values()),
+        num_buckets=N,
+        random_seed=42,
+    )
+)
+counts = [p.count().execute() for p in partitions]
+total = sum(counts)
+
+for i, partition_name in enumerate(partition_info.keys()):
+    print(f"{partition_name.upper()} Ratio: {round(counts[i]/ total,2)}")

--- a/python/letsql/expr/api.py
+++ b/python/letsql/expr/api.py
@@ -40,9 +40,7 @@ from letsql.expr.relations import (
     CachedNode,
     register_and_transform_remote_tables,
 )
-
-from letsql.expr.ml import train_tests_splits
-
+from letsql.expr.ml import _train_test_splits
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -1691,4 +1689,4 @@ def to_parquet(
 
 
 def train_test_splits(*args, **kwargs) -> Iterator[tuple[ir.Table, ir.Table]]:
-    return train_tests_splits(*args, **kwargs)
+    return _train_test_splits(*args, **kwargs)

--- a/python/letsql/expr/api.py
+++ b/python/letsql/expr/api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime
 import functools
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Union, overload, Mapping
+from typing import TYPE_CHECKING, Any, Union, overload, Iterable, Iterator, Mapping
 
 import ibis
 import ibis.expr.builders as bl
@@ -40,6 +40,8 @@ from letsql.expr.relations import (
     CachedNode,
     register_and_transform_remote_tables,
 )
+
+from letsql.expr.ml import train_tests_splits
 
 
 if TYPE_CHECKING:
@@ -108,6 +110,7 @@ __all__ = (
     "table",
     "time",
     "today",
+    "train_test_splits",
     "to_parquet",
     "to_pyarrow",
     "to_pyarrow_batches",
@@ -1685,3 +1688,7 @@ def to_parquet(
         with pq.ParquetWriter(path, batch_reader.schema, **kwargs) as writer:
             for batch in batch_reader:
                 writer.write_batch(batch)
+
+
+def train_test_splits(*args, **kwargs) -> Iterator[tuple[ir.Table, ir.Table]]:
+    return train_tests_splits(*args, **kwargs)

--- a/python/letsql/expr/api.py
+++ b/python/letsql/expr/api.py
@@ -40,7 +40,7 @@ from letsql.expr.relations import (
     CachedNode,
     register_and_transform_remote_tables,
 )
-from letsql.expr.ml import _train_test_splits
+from letsql.expr import ml
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -1689,4 +1689,4 @@ def to_parquet(
 
 
 def train_test_splits(*args, **kwargs) -> Iterator[tuple[ir.Table, ir.Table]]:
-    return _train_test_splits(*args, **kwargs)
+    return ml.train_test_splits(*args, **kwargs)

--- a/python/letsql/expr/api.py
+++ b/python/letsql/expr/api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime
 import functools
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Union, overload, Iterable, Iterator, Mapping
+from typing import TYPE_CHECKING, Any, Union, overload, Iterable, Mapping
 
 import ibis
 import ibis.expr.builders as bl
@@ -40,7 +40,7 @@ from letsql.expr.relations import (
     CachedNode,
     register_and_transform_remote_tables,
 )
-from letsql.expr import ml
+from letsql.expr.ml import train_test_splits
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -1686,7 +1686,3 @@ def to_parquet(
         with pq.ParquetWriter(path, batch_reader.schema, **kwargs) as writer:
             for batch in batch_reader:
                 writer.write_batch(batch)
-
-
-def train_test_splits(*args, **kwargs) -> Iterator[tuple[ir.Table, ir.Table]]:
-    return ml.train_test_splits(*args, **kwargs)

--- a/python/letsql/expr/ml.py
+++ b/python/letsql/expr/ml.py
@@ -1,0 +1,143 @@
+from random import Random
+from typing import Tuple, Iterable, List, Iterator
+
+# TODO: How should we / should we enforce letsql table ?
+import ibis.expr.types as ir
+from ibis import literal
+
+
+def _calculate_bounds(test_sizes: List[float]) -> List[Tuple[float, float]]:
+    """
+    Calculates the cumulative sum of test_sizes and generates bounds for splitting data.
+
+    Parameters
+    ----------
+    test_sizes : List[float]
+        A list of floats representing the desired proportions for data splits.
+        Each value should be between 0 and 1, and their sum should ideally be less than or equal to 1.
+
+    Returns
+    -------
+    List[Tuple[float, float]]
+        A list of tuples, where each tuple contains two floats representing the
+        lower and upper bounds for a split. These bounds are calculated based on
+        the cumulative sum of the `test_sizes`.
+    """
+
+    num_splits = len(test_sizes)
+    cumulative_sizes = [sum(test_sizes[: i + 1]) for i in range(num_splits)]
+    cumulative_sizes.insert(0, 0.0)
+    bounds = [(cumulative_sizes[i], cumulative_sizes[i + 1]) for i in range(num_splits)]
+    return bounds
+
+
+def train_test_splits(
+    table: ir.Table,
+    unique_key: str | list[str],
+    test_sizes: Iterable[float] | float,
+    num_buckets: int = 10000,
+    random_seed: int | None = None,
+) -> Iterator[ir.Table]:
+    """Generates multiple train/test splits of an Ibis table for different test sizes.
+
+    This function splits an Ibis table into multiple subsets based on a unique key
+    or combination of keys and a list of test sizes. It uses a hashing function to
+    convert the unique key into an integer, then applies a modulo operation to split
+    the data into buckets. Each subset of data is defined by a range of
+    buckets determined by the cumulative sum of the test sizes.
+
+    Parameters
+    ----------
+    table : ir.Table
+        The input Ibis table to be split.
+    unique_key : str | list[str]
+        The column name(s) that uniquely identify each row in the table. This
+        unique_key is used to create a deterministic split of the dataset
+        through a hashing process.
+    test_sizes : Iterable[float] | float
+        An iterable of floats representing the desired proportions for data splits.
+        Each value should be between 0 and 1, and their sum must equal 1. The
+        order of test sizes determines the order of the generated subsets. If float is passed
+        it assumes that the value is for the test size and that a tradition tain test split of (1-test_size, test_size) is returned.
+    num_buckets : int, optional
+        The number of buckets into which the data can be binned after being
+        hashed (default is 10000). It controls how finely the data is divided
+        during the split process. Adjusting num_buckets can affect the
+        granularity and efficiency of the splitting operation, balancing
+        between accuracy and computational efficiency.
+    random_seed : int | None, optional
+        Seed for the random number generator. If provided, ensures
+        reproducibility of the split (default is None).
+
+    Returns
+    -------
+    Iterator[ir.Table]
+        An iterator yielding Ibis table expressions, each representing a mutually exclusive
+        subset of the original table based on the specified test sizes.
+
+    Raises
+    ------
+    ValueError
+        If any value in `test_sizes` is not between 0 and 1.
+        If `test_sizes` does not sum to 1.
+        If `num_buckets` is not an integer greater than 1.
+
+    Examples
+    --------
+    >>> import letsql as ls
+    >>> import ibis
+    >>> table = ibis.memtable({"key": range(100), "value": range(100,200)})
+    >>> unique_key = "key"
+    >>> test_sizes = [0.2, 0.3, 0.5]
+    >>> splits = ls.train_test_splits(table, unique_key, test_sizes, num_buckets=10, random_seed=42)
+    >>> for i, split_table in enumerate(splits):
+    ...     print(f"Split {i+1} size: {split_table.count().execute()}")
+    ...     print(split_table.execute())
+    Split 1 size: 20
+    Split 2 size: 30
+    Split 3 size: 50
+    """
+    # Convert to traditional train test split
+    if isinstance(test_sizes, float):
+        test_sizes = [1 - test_sizes, test_sizes]
+
+    if not all(isinstance(test_size, float) for test_size in test_sizes):
+        raise ValueError("Test size must be float.")
+
+    if not all((0 < test_size < 1) for test_size in test_sizes):
+        raise ValueError("test size should be a float between 0 and 1.")
+
+    if not (isinstance(num_buckets, int)):
+        raise ValueError("num_buckets must be an integer.")
+
+    if not (num_buckets > 1 and isinstance(num_buckets, int)):
+        raise ValueError(
+            "num_buckets = 1 places all data into training set. For any integer x  >=0 , x mod 1 = 0 . "
+        )
+
+    if not sum(test_sizes) == 1:
+        raise ValueError("Test sizes must sum to 1")
+
+    # Get cumulative bounds
+    bounds = _calculate_bounds(test_sizes=test_sizes)
+
+    # Set the random seed if set, & Generate a random 256-bit key
+    random_str = str(Random(random_seed).getrandbits(256))
+
+    if isinstance(unique_key, str):
+        unique_key = [unique_key]
+
+    comb_key = literal(",").join(table[col].cast("str") for col in unique_key)
+
+    table = table.mutate(**{"hash": (comb_key + random_str).hash().abs() % num_buckets})
+    train_test_filters = [
+        (
+            literal(bound[0]).cast("decimal(38, 9)") * num_buckets <= table.hash
+        )  # lower bound condition
+        & (
+            table.hash < literal(bound[1]).cast("decimal(38, 9)") * num_buckets
+        )  # upper bound condition
+        for i, bound in enumerate(bounds)
+    ]
+
+    return (table.filter(_filter).drop(["hash"]) for _filter in train_test_filters)

--- a/python/letsql/expr/ml.py
+++ b/python/letsql/expr/ml.py
@@ -31,7 +31,7 @@ def _calculate_bounds(test_sizes: List[float]) -> List[Tuple[float, float]]:
     return bounds
 
 
-def train_test_splits(
+def _train_test_splits(
     table: ir.Table,
     unique_key: str | list[str],
     test_sizes: Iterable[float] | float,

--- a/python/letsql/tests/conftest.py
+++ b/python/letsql/tests/conftest.py
@@ -11,7 +11,6 @@ from letsql.common.utils.aws_utils import (
     make_s3_credentials_defaults,
 )
 
-import os
 
 TEST_TABLES = {
     "functional_alltypes": ibis.schema(
@@ -281,29 +280,3 @@ def struct(con):
 @pytest.fixture(scope="session")
 def struct_df(struct):
     return struct.execute()
-
-
-# TODO: rename or move ?
-@pytest.fixture(scope="module")
-def create_passing_connections():
-    connections = {
-        "letsql": ls.connect(),
-        "duckdb": ls.duckdb.connect(),
-        "postgres": ls.postgres.connect(
-            host=os.environ["POSTGRES_HOST"],
-            user=os.environ["POSTGRES_USER"],
-            password=os.environ["POSTGRES_PASSWORD"],
-            port=int(os.environ["POSTGRES_PORT"]),
-            database=os.environ["POSTGRES_DATABASE"],
-        ),
-    }
-    return connections
-
-
-# TODO: rename or move ?
-@pytest.fixture(scope="module")
-def create_failing_connections():
-    connections = {
-        "datafusion": ls.datafusion.connect(),
-    }
-    return connections

--- a/python/letsql/tests/conftest.py
+++ b/python/letsql/tests/conftest.py
@@ -283,11 +283,11 @@ def struct_df(struct):
     return struct.execute()
 
 
+# TODO: rename or move ?
 @pytest.fixture(scope="module")
-def create_connections():
+def create_passing_connections():
     connections = {
         "letsql": ls.connect(),
-        "datafusion": ls.datafusion.connect(),
         "duckdb": ls.duckdb.connect(),
         "postgres": ls.postgres.connect(
             host=os.environ["POSTGRES_HOST"],
@@ -296,5 +296,14 @@ def create_connections():
             port=int(os.environ["POSTGRES_PORT"]),
             database=os.environ["POSTGRES_DATABASE"],
         ),
+    }
+    return connections
+
+
+# TODO: rename or move ?
+@pytest.fixture(scope="module")
+def create_failing_connections():
+    connections = {
+        "datafusion": ls.datafusion.connect(),
     }
     return connections

--- a/python/letsql/tests/conftest.py
+++ b/python/letsql/tests/conftest.py
@@ -11,6 +11,8 @@ from letsql.common.utils.aws_utils import (
     make_s3_credentials_defaults,
 )
 
+import os
+
 TEST_TABLES = {
     "functional_alltypes": ibis.schema(
         {
@@ -279,3 +281,20 @@ def struct(con):
 @pytest.fixture(scope="session")
 def struct_df(struct):
     return struct.execute()
+
+
+@pytest.fixture(scope="module")
+def create_connections():
+    connections = {
+        "letsql": ls.connect(),
+        "datafusion": ls.datafusion.connect(),
+        "duckdb": ls.duckdb.connect(),
+        "postgres": ls.postgres.connect(
+            host=os.environ["POSTGRES_HOST"],
+            user=os.environ["POSTGRES_USER"],
+            password=os.environ["POSTGRES_PASSWORD"],
+            port=int(os.environ["POSTGRES_PORT"]),
+            database=os.environ["POSTGRES_DATABASE"],
+        ),
+    }
+    return connections

--- a/python/letsql/tests/test_ml.py
+++ b/python/letsql/tests/test_ml.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from ibis import memtable
+import pytest
+import letsql as ls
+from letsql.expr.ml import _calculate_bounds
+
+from letsql.tests.util import assert_frame_equal
+
+
+def test_train_test_splits_intersections():
+    # This is testing the base case where a single float becomes ( 1-test_size , test_size ) proportion
+    # Check counts and overlaps in train and test dataset
+    N = 10000
+    test_size = [0.1, 0.2, 0.7]
+
+    # init table
+    table = memtable([(i, "val") for i in range(N)], columns=["key1", "val"])
+    results = [
+        r
+        for r in ls.train_test_splits(
+            table,
+            unique_key="key1",
+            test_sizes=test_size,
+            num_buckets=N,
+            random_seed=42,
+        )
+    ]
+
+    # make sure all splits mutually exclusive
+    # These are all  a \ b  U  a intersect b  where b are the other splits
+    element1 = results[0]
+    complement1 = results[1].union(results[2])
+
+    element2 = results[1]
+    complement2 = results[0].union(results[2])
+
+    element3 = results[2]
+    complement3 = results[0].union(results[1])
+
+    assert element1.union(complement1).join(table, how="anti").count().execute() == 0
+    assert (
+        element1.join(complement1, element1.key1 == complement1.key1).count().execute()
+        == 0
+    )
+
+    assert element2.union(complement2).join(table, how="anti").count().execute() == 0
+    assert (
+        element2.join(complement2, element2.key1 == complement2.key1).count().execute()
+        == 0
+    )
+
+    assert element3.union(complement3).join(table, how="anti").count().execute() == 0
+    assert (
+        element3.join(complement3, element3.key1 == complement3.key1).count().execute()
+        == 0
+    )
+
+
+def test_train_test_split():
+    # This is testing the base case where a single float becomes ( 1-test_size , test_size ) proportion
+    # Check counts and overlaps in train and test dataset
+    N = 100
+    test_size = 0.25
+
+    # init table
+    table = memtable([(i, "val") for i in range(N)], columns=["key1", "val"])
+    train_table, test_table = ls.train_test_splits(
+        table, unique_key="key1", test_sizes=test_size, num_buckets=N, random_seed=42
+    )
+    # These values are for seed 42
+    assert train_table.count().execute() == 73
+    assert test_table.count().execute() == 27
+    assert set(train_table.columns) == set(table.columns)
+    assert set(test_table.columns) == set(table.columns)
+    # make sure data unioned together is itself
+    assert train_table.union(test_table).join(table, how="semi").count().execute() == N
+
+    # Check reproducibility
+    reproduced_train_table, reproduced_test_table = ls.train_test_splits(
+        table, unique_key="key1", test_sizes=test_size, num_buckets=N, random_seed=42
+    )
+    assert_frame_equal(train_table.execute(), reproduced_train_table.execute())
+    assert_frame_equal(test_table.execute(), reproduced_test_table.execute())
+
+    # make sure it could generate different data with different random_seed
+    different_train_table, different_test_table = ls.train_test_splits(
+        table, unique_key="key1", test_sizes=test_size, num_buckets=N, random_seed=0
+    )
+    assert not train_table.execute().equals(different_train_table.execute())
+    assert not test_table.execute().equals(different_test_table.execute())
+
+
+def test_train_test_split_invalid_test_size():
+    table = memtable({"key": [1, 2, 3]})
+    with pytest.raises(ValueError, match="test size should be a float between 0 and 1"):
+        ls.train_test_splits(table, unique_key="key", test_sizes=1.5)
+    with pytest.raises(ValueError, match="test size should be a float between 0 and 1"):
+        ls.train_test_splits(table, unique_key="key", test_sizes=-0.5)
+
+
+def test_train_test_split_invalid_num_buckets_type():
+    table = memtable({"key": [1, 2, 3]})
+    with pytest.raises(ValueError, match="num_buckets must be an integer"):
+        ls.train_test_splits(table, unique_key="key", test_sizes=0.5, num_buckets=10.5)
+
+
+def test_train_test_split_invalid_num_buckets_value():
+    table = memtable({"key": [1, 2, 3]})
+    with pytest.raises(
+        ValueError, match="num_buckets = 1 places all data into training set"
+    ):
+        ls.train_test_splits(table, unique_key="key", test_sizes=0.5, num_buckets=1)
+
+
+def test_train_test_split_multiple_keys():
+    data = {
+        "key1": range(100),
+        "key2": [chr(i % 26 + 65) for i in range(100)],  # A, B, C, ...
+        "value": [i % 3 for i in range(100)],
+    }
+    table = memtable(data)
+    train_table, test_table = ls.train_test_splits(
+        table,
+        unique_key=["key1", "key2"],
+        test_sizes=0.25,
+        num_buckets=10,
+        random_seed=99,
+    )
+    assert train_table.union(test_table).join(table, how="anti").count().execute() == 0
+
+
+def test_train_test_splits_deterministic_with_seed():
+    table = memtable({"key": range(100), "value": range(100)})
+    test_sizes = [0.4, 0.6]
+
+    splits1 = list(
+        ls.train_test_splits(table, "key", test_sizes, random_seed=123, num_buckets=10)
+    )
+    splits2 = list(
+        ls.train_test_splits(table, "key", test_sizes, random_seed=123, num_buckets=10)
+    )
+
+    result1_all = splits1[0].union(splits1[1]).execute()
+    result2_all = splits2[0].union(splits2[1]).execute()
+    assert result1_all.equals(result2_all)
+
+
+def test_train_test_splits_invalid_test_sizes():
+    table = memtable({"key": [1, 2, 3], "value": [4, 5, 6]})
+    with pytest.raises(ValueError, match="Test size must be float."):
+        next(ls.train_test_splits(table, "key", ["a", "b"]))
+    with pytest.raises(
+        ValueError, match="test size should be a float between 0 and 1."
+    ):
+        next(ls.train_test_splits(table, "key", [-0.1, 0.5]))
+
+
+def test_train_test_splits_must_sum_one():
+    table = memtable({"key": [1, 2, 3], "value": [4, 5, 6]})
+    with pytest.raises(ValueError, match="Test sizes must sum to 1"):
+        next(ls.train_test_splits(table, "key", [0.1, 0.5]))
+
+
+def test_calculate_bounds():
+    test_sizes = [0.2, 0.3, 0.5]
+    expected_bounds = [(0.0, 0.2), (0.2, 0.5), (0.5, 1.0)]
+    assert _calculate_bounds(test_sizes) == expected_bounds
+
+
+def test_train_test_splits_num_buckets_gt_one():
+    table = memtable({"key": range(100), "value": range(100)})
+    test_sizes = [0.4, 0.6]
+    with pytest.raises(
+        ValueError,
+        match="num_buckets = 1 places all data into training set. For any integer x  >=0 , x mod 1 = 0 . ",
+    ):
+        next(
+            ls.train_test_splits(
+                table, "key", test_sizes, random_seed=123, num_buckets=1
+            )
+        )


### PR DESCRIPTION
This PR adds functionality for a train test split to letsql. 

 I have not updated the crate to bump semantic version.

```python
  import letsql as ls 
  table = memtable([(i, "val") for i in range(N)], columns=["key1", "val"])
  train_table, test_table = ls.train_test_split(
      table, unique_key="key1", test_sizes=test_size, random_seed=42
  )
```

There was a name space conflict of some sort so there is some odd imports at the top `api.py` , this will be fixed. 
It needs more tests on errors & maybe a warning about how bin size & its impact on  train test split percentages, but. I wanted to get something out there to receive feedback. 

if `test_size` is a `float` you will get back   train , test sets with a proportion of (1 - test_size) , ( test_size) 
Otherwise `test_sizes` must be an iterable of floats that sum to 1.

```python
# If test sizes is a list of floats , mutually exclusive deferred partitions will be returned
partition_proportions = [0.1, 0.2, 0.3, 0.4]


hold_out, test, validation, training = ls.train_test_splits(
    table,
    unique_key="key1",
    test_sizes=partition_proportions,
    num_buckets=N,
    random_seed=42,
)
``` 

