### PR TITLE
chore: enforce import order

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -42,7 +42,7 @@ jobs:
           pip install ruff
       # Update output format to enable automatic inline annotations.
       - name: Run Ruff
-        run: ruff check --output-format=github .
+        run: ruff check --output-format=github python examples docs
       - name: Check Formatting
         uses: actions-rs/cargo@v1
         with:

--- a/docs/_renderer.py
+++ b/docs/_renderer.py
@@ -66,9 +66,9 @@ class Renderer(qd.MdRenderer):
                 if expect_failure in first or any(
                     expect_failure in line for line in rest
                 ):
-                    assert (
-                        start and end
-                    ), "expected failure should never occur alongside a skipped doctest example"
+                    assert start and end, (
+                        "expected failure should never occur alongside a skipped doctest example"
+                    )
                     result.append("#| error: true")
 
                 # remove the quartodoc markers from the rendered code

--- a/docs/_supported.py
+++ b/docs/_supported.py
@@ -13,32 +13,33 @@ from ibis.expr.types.arrays import ArrayValue
 from ibis.expr.types.binary import BinaryValue
 from ibis.expr.types.collections import SetValue
 from ibis.expr.types.core import Expr
-from ibis.expr.types.generic import Value, Scalar, Column
+from ibis.expr.types.generic import Column, Scalar, Value
 from ibis.expr.types.geospatial import GeoSpatialValue
-from ibis.expr.types.inet import MACADDRValue, INETValue
+from ibis.expr.types.inet import INETValue, MACADDRValue
 from ibis.expr.types.joins import Join
 from ibis.expr.types.json import JSONValue
-from ibis.expr.types.logical import BooleanValue, BooleanColumn
+from ibis.expr.types.logical import BooleanColumn, BooleanValue
 from ibis.expr.types.maps import MapValue
 from ibis.expr.types.numeric import (
-    NumericColumn,
-    IntegerColumn,
-    FloatingColumn,
     DecimalColumn,
+    FloatingColumn,
+    IntegerColumn,
+    NumericColumn,
 )
 from ibis.expr.types.relations import Table
 from ibis.expr.types.strings import StringValue
 from ibis.expr.types.structs import StructValue
 from ibis.expr.types.temporal import (
-    TimeValue,
     DateValue,
-    TimestampValue,
-    IntervalValue,
     DayOfWeek,
+    IntervalValue,
+    TimestampValue,
+    TimeValue,
 )
 from ibis.expr.types.uuid import UUIDValue
 
 from letsql.backends.let import Backend as LETSQLBackend
+
 
 support_matrix_ignored_operations = (ops.ScalarParameter,)
 

--- a/docs/api/_utils.py
+++ b/docs/api/_utils.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from quartodoc import MdRenderer, get_object
 
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 

--- a/examples/deferred_read_csv.py
+++ b/examples/deferred_read_csv.py
@@ -1,5 +1,4 @@
 import letsql as ls
-
 from letsql import _
 from letsql.common.utils.defer_utils import (
     deferred_read_csv,

--- a/examples/into_backend_example.py
+++ b/examples/into_backend_example.py
@@ -2,6 +2,7 @@ import letsql as ls
 from letsql.common.caching import SourceStorage
 from letsql.expr.relations import into_backend
 
+
 con = ls.connect()
 pg = ls.postgres.connect_env()
 

--- a/examples/multi_engine.py
+++ b/examples/multi_engine.py
@@ -1,6 +1,7 @@
 import letsql as ls
 from letsql.expr.relations import into_backend
 
+
 pg = ls.postgres.connect_env()
 db = ls.duckdb.connect()
 

--- a/examples/pandas_example.py
+++ b/examples/pandas_example.py
@@ -2,6 +2,7 @@ import pandas as pd
 
 import letsql as ls
 
+
 con = ls.connect()
 
 df = pd.DataFrame({"a": [1, 2, 3, 4, 5], "b": [2, 3, 4, 5, 6]})

--- a/examples/penguins_example.py
+++ b/examples/penguins_example.py
@@ -1,6 +1,8 @@
+from pathlib import Path
+
 import letsql as ls
 from letsql.common.caching import ParquetCacheStorage
-from pathlib import Path
+
 
 t = ls.examples.penguins.fetch()
 

--- a/examples/postgres_caching.py
+++ b/examples/postgres_caching.py
@@ -2,6 +2,7 @@ import letsql as ls
 from letsql import _
 from letsql.common.caching import ParquetCacheStorage
 
+
 pg = ls.postgres.connect_examples()
 con = ls.connect()
 

--- a/examples/remote_caching.py
+++ b/examples/remote_caching.py
@@ -1,7 +1,7 @@
 import letsql as ls
-
 from letsql import _
 from letsql.common.caching import SourceStorage
+
 
 con = ls.connect()
 ddb = ls.duckdb.connect()

--- a/examples/train_test_splits.py
+++ b/examples/train_test_splits.py
@@ -1,6 +1,7 @@
 import letsql as ls
 from letsql import memtable
 
+
 N = 100000
 # if single float deferred partitions of train and test will be returned
 # With proportions (1-test_size, test_size)
@@ -16,8 +17,8 @@ train_table, test_table = ls.train_test_splits(
 train_count = train_table.count().execute()
 test_count = test_table.count().execute()
 total = train_count + test_count
-print(f"train ratio: {round(train_count/total,2)}")
-print(f"test ratio: {round(test_count/total,2)}\n")
+print(f"train ratio: {round(train_count / total, 2)}")
+print(f"test ratio: {round(test_count / total, 2)}\n")
 
 
 # If test sizes is a list of floats , mutually exclusive partitions will be returned
@@ -41,4 +42,4 @@ counts = [p.count().execute() for p in partitions]
 total = sum(counts)
 
 for i, partition_name in enumerate(partition_info.keys()):
-    print(f"{partition_name.upper()} Ratio: {round(counts[i]/ total,2)}")
+    print(f"{partition_name.upper()} Ratio: {round(counts[i] / total, 2)}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,10 +112,19 @@ python-source = "python"
 features = ["pyo3/extension-module"]
 
 [tool.ruff.lint]
+select = ["I"]
 extend-select = ["ICN"]
+
+[tool.ruff.lint.per-file-ignores]
+"python/letsql/__init__.py" = ["I001"]
 
 [tool.ruff.lint.flake8-import-conventions.extend-aliases]
 "letsql" = "ls"
+
+[tool.ruff.lint.isort]
+known-first-party = ["letsql"]
+section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
+lines-after-imports = 2
 
 [tool.codespell]
 skip = "*.lock,.direnv,.git,docs/_freeze/**/html.json"

--- a/python/letsql/__init__.py
+++ b/python/letsql/__init__.py
@@ -11,7 +11,6 @@ from letsql.expr.api import *  # noqa: F403
 from letsql.backends.let import Backend
 from letsql.internal import SessionConfig
 
-
 try:
     import importlib.metadata as importlib_metadata
 except ModuleNotFoundError:
@@ -39,6 +38,7 @@ def load_backend(name):
         (ep for ep in _load_entry_points() if ep.name == name), None
     ):
         import types
+
         import letsql as ls
 
         module = entry_point.load()

--- a/python/letsql/backends/datafusion/__init__.py
+++ b/python/letsql/backends/datafusion/__init__.py
@@ -11,10 +11,10 @@ import pyarrow as pa
 import pyarrow_hotfix  # noqa: F401
 import sqlglot as sg
 import sqlglot.expressions as sge
-
 from ibis.backends.datafusion import Backend as IbisDatafusionBackend
 from ibis.common.dispatch import lazy_singledispatch
 from ibis.util import gen_name
+
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/python/letsql/backends/duckdb/__init__.py
+++ b/python/letsql/backends/duckdb/__init__.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Any
+from typing import Any, Mapping
 
 import pyarrow as pa
 from ibis.backends.duckdb import Backend as IbisDuckDBBackend

--- a/python/letsql/backends/let/__init__.py
+++ b/python/letsql/backends/let/__init__.py
@@ -7,7 +7,8 @@ from typing import Any
 import pandas as pd
 import pyarrow as pa
 import pyarrow_hotfix  # noqa: F401
-from ibis.expr import types as ir, schema as sch
+from ibis.expr import schema as sch
+from ibis.expr import types as ir
 from sqlglot import exp, parse_one
 
 import letsql.backends.let.hotfix  # noqa: F401
@@ -18,7 +19,7 @@ from letsql.expr.relations import (
     CachedNode,
     replace_cache_table,
 )
-from letsql.internal import WindowUDF, SessionConfig
+from letsql.internal import SessionConfig, WindowUDF
 
 
 def _get_datafusion_table(con, table_name, database="public"):

--- a/python/letsql/backends/let/datafusion/__init__.py
+++ b/python/letsql/backends/let/datafusion/__init__.py
@@ -29,11 +29,9 @@ from ibis.backends.sql.compilers.base import C
 from ibis.common.annotations import Argument
 from ibis.common.dispatch import lazy_singledispatch
 from ibis.expr.operations import Namespace
-from ibis.expr.operations.udf import InputType
-from ibis.expr.operations.udf import ScalarUDF
-from ibis.formats.pyarrow import PyArrowType
+from ibis.expr.operations.udf import InputType, ScalarUDF
+from ibis.formats.pyarrow import PyArrowType, _from_pyarrow_types
 from ibis.util import gen_name, normalize_filename
-from ibis.formats.pyarrow import _from_pyarrow_types
 
 import letsql as ls
 import letsql.internal as df
@@ -51,6 +49,7 @@ from letsql.internal import (
     WindowEvaluator,
     udwf,
 )
+
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/python/letsql/backends/let/datafusion/compiler.py
+++ b/python/letsql/backends/let/datafusion/compiler.py
@@ -4,7 +4,7 @@ import calendar
 import math
 from functools import partial
 from itertools import starmap
-from typing import Mapping, Any
+from typing import Any, Mapping
 
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
@@ -18,6 +18,7 @@ from ibis.backends.sql.rewrites import split_select_distinct_with_order_by
 from ibis.common.temporal import IntervalUnit, TimestampUnit
 from ibis.expr import types as ir
 from ibis.expr.operations.udf import InputType
+
 
 _UNIX_EPOCH = "1970-01-01T00:00:00Z"
 

--- a/python/letsql/backends/let/datafusion/tests/test_provider.py
+++ b/python/letsql/backends/let/datafusion/tests/test_provider.py
@@ -1,15 +1,15 @@
 import os
 from pathlib import Path
 
-import pyarrow as pa
 import pandas as pd
+import pyarrow as pa
 import pytest
 import xgboost as xgb
+from ibis import udf
+from sklearn.model_selection import train_test_split
 
 import letsql as ls
-from ibis import udf
 from letsql.backends.let.datafusion.provider import IbisTableProvider
-from sklearn.model_selection import train_test_split
 
 
 @pytest.fixture

--- a/python/letsql/backends/let/hotfix.py
+++ b/python/letsql/backends/let/hotfix.py
@@ -1,8 +1,8 @@
-import ibis.formats.pyarrow
 import ibis.expr.datatypes.core
 import ibis.expr.operations as ops
 import ibis.expr.types.core
 import ibis.expr.types.relations
+import ibis.formats.pyarrow
 from attr import (
     field,
     frozen,

--- a/python/letsql/backends/let/tests/conftest.py
+++ b/python/letsql/backends/let/tests/conftest.py
@@ -1,5 +1,5 @@
-import pytest
 import pyarrow as pa
+import pytest
 
 import letsql as ls
 

--- a/python/letsql/backends/let/tests/test_api.py
+++ b/python/letsql/backends/let/tests/test_api.py
@@ -88,8 +88,9 @@ def test_read_sqlite(tmp_path):
 def test_with_config(
     with_repartition_file_scans, keep_partition_by_columns, parquet_dir
 ):
-    from letsql import SessionConfig
     import pandas as pd
+
+    from letsql import SessionConfig
 
     session_config = (
         SessionConfig()

--- a/python/letsql/backends/let/tests/test_cache.py
+++ b/python/letsql/backends/let/tests/test_cache.py
@@ -20,8 +20,8 @@ from letsql.backends.conftest import (
     get_storage_uncached,
 )
 from letsql.common.caching import (
-    ParquetSnapshot,
     ParquetCacheStorage,
+    ParquetSnapshot,
     SnapshotStorage,
     SourceStorage,
 )

--- a/python/letsql/backends/let/tests/test_execute.py
+++ b/python/letsql/backends/let/tests/test_execute.py
@@ -9,11 +9,11 @@ import pytest
 from pytest import param
 
 import letsql as ls
+from letsql.common.caching import SourceStorage
 from letsql.expr.relations import into_backend
 from letsql.tests.util import (
     assert_frame_equal,
 )
-from letsql.common.caching import SourceStorage
 
 
 KEY_PREFIX = ls.config.options.cache.key_prefix

--- a/python/letsql/backends/let/tests/test_ls_accessor.py
+++ b/python/letsql/backends/let/tests/test_ls_accessor.py
@@ -1,7 +1,6 @@
 import pytest
 
 import letsql as ls
-
 from letsql.backends.let import Backend
 from letsql.common.caching import (
     ParquetCacheStorage,

--- a/python/letsql/backends/let/tests/test_udwf_dataframe.py
+++ b/python/letsql/backends/let/tests/test_udwf_dataframe.py
@@ -4,7 +4,6 @@ import pyarrow as pa
 import pytest
 from ibis import _
 
-
 import letsql as ls
 from letsql.expr.udf import pyarrow_udwf
 from letsql.internal import WindowEvaluator

--- a/python/letsql/backends/postgres/__init__.py
+++ b/python/letsql/backends/postgres/__init__.py
@@ -1,6 +1,6 @@
 from functools import partial
 from pathlib import Path
-from typing import Mapping, Any
+from typing import Any, Mapping
 
 import ibis.expr.schema as sch
 import pyarrow as pa

--- a/python/letsql/backends/postgres/compiler.py
+++ b/python/letsql/backends/postgres/compiler.py
@@ -4,6 +4,7 @@ from ibis.backends.sql.compilers.postgres import (
     PostgresCompiler as IbisPostgresCompiler,
 )
 
+
 _UNIX_EPOCH = "1970-01-01T00:00:00Z"
 
 

--- a/python/letsql/backends/snowflake/__init__.py
+++ b/python/letsql/backends/snowflake/__init__.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Any
+from typing import Any, Mapping
 
 import ibis.expr.types as ir
 from ibis.backends.snowflake import Backend as IbisSnowflakeBackend

--- a/python/letsql/backends/snowflake/hotfix.py
+++ b/python/letsql/backends/snowflake/hotfix.py
@@ -3,8 +3,8 @@ import itertools
 import warnings
 
 import ibis
-import ibis.expr.types as ir
 import ibis.expr.schema as sch
+import ibis.expr.types as ir
 import pandas as pd
 import pyarrow as pa
 import sqlglot as sg

--- a/python/letsql/backends/snowflake/tests/conftest.py
+++ b/python/letsql/backends/snowflake/tests/conftest.py
@@ -1,10 +1,11 @@
 from contextlib import contextmanager
 
-import letsql as ls
 import pytest
 import sqlglot as sg
 import sqlglot.expressions as sge
 from ibis.util import gen_name
+
+import letsql as ls
 
 
 SU = pytest.importorskip("letsql.common.utils.snowflake_utils")

--- a/python/letsql/backends/snowflake/tests/test_client.py
+++ b/python/letsql/backends/snowflake/tests/test_client.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 SU = pytest.importorskip("letsql.common.utils.snowflake_utils")
 
 

--- a/python/letsql/common/caching.py
+++ b/python/letsql/common/caching.py
@@ -12,7 +12,6 @@ import dask
 import ibis
 import ibis.expr.operations as ops
 import toolz
-from ibis.expr import types as ir
 from attr import (
     field,
     frozen,
@@ -20,10 +19,10 @@ from attr import (
 from attr.validators import (
     instance_of,
 )
+from ibis.expr import types as ir
 
 import letsql as ls
 import letsql.common.utils.dask_normalize  # noqa: F401
-
 from letsql.common.utils.dask_normalize import (
     patch_normalize_token,
 )

--- a/python/letsql/common/collections.py
+++ b/python/letsql/common/collections.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Dict
 
 from ibis.expr.operations import relations as ops
+
 from letsql.expr.relations import (
     CachedNode,
     Read,
@@ -10,7 +11,13 @@ from letsql.expr.relations import (
 
 
 def _find_backend(value):
-    node_types = (ops.UnboundTable, ops.DatabaseTable, ops.SQLQueryResult, CachedNode, Read)
+    node_types = (
+        ops.UnboundTable,
+        ops.DatabaseTable,
+        ops.SQLQueryResult,
+        CachedNode,
+        Read,
+    )
     (backend, *rest) = set(table.source for table in value.find(node_types))
     if len(rest) > 1:
         raise ValueError("Multiple backends found for this expression")

--- a/python/letsql/common/tests/test_cache.py
+++ b/python/letsql/common/tests/test_cache.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
-import letsql as ls
 import pytest
 
+import letsql as ls
 import letsql.backends.let
 from letsql.common.caching import ParquetCacheStorage
 

--- a/python/letsql/common/utils/caching_utils.py
+++ b/python/letsql/common/utils/caching_utils.py
@@ -1,6 +1,7 @@
 from ibis import BaseBackend
-from letsql.expr.relations import CachedNode, Read
 from ibis.expr import operations as ops
+
+from letsql.expr.relations import CachedNode, Read
 
 
 def find_backend(op: ops.Node, use_default=False) -> tuple[BaseBackend, bool]:

--- a/python/letsql/common/utils/dask_normalize_expr.py
+++ b/python/letsql/common/utils/dask_normalize_expr.py
@@ -16,8 +16,8 @@ from letsql.common.utils.defer_utils import (
     Read,
 )
 from letsql.expr.relations import (
-    make_native_op,
     RemoteTable,
+    make_native_op,
 )
 
 

--- a/python/letsql/common/utils/dask_normalize_function.py
+++ b/python/letsql/common/utils/dask_normalize_function.py
@@ -3,9 +3,11 @@ import types
 
 import dask.base
 import toolz
+
 from letsql.common.utils.inspect_utils import (
     get_partial_arguments,
 )
+
 
 CODE_ATTRS = (
     "co_argcount",

--- a/python/letsql/common/utils/defer_utils.py
+++ b/python/letsql/common/utils/defer_utils.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pyarrow as pa
 import sqlglot as sg
 import toolz
+from ibis.backends.sql.compilers.base import SQLGlotCompiler
 from ibis.util import (
     gen_name,
 )
@@ -19,7 +20,6 @@ from letsql.expr.relations import (
     Read,
 )
 
-from ibis.backends.sql.compilers.base import SQLGlotCompiler
 
 DEFAULT_CHUNKSIZE = 10_000
 

--- a/python/letsql/common/utils/hotfix_utils.py
+++ b/python/letsql/common/utils/hotfix_utils.py
@@ -3,6 +3,7 @@ import warnings
 import dask
 import toolz
 
+
 try:
     import cityhash  # noqa: F401
 except ImportError:

--- a/python/letsql/common/utils/postgres_utils.py
+++ b/python/letsql/common/utils/postgres_utils.py
@@ -19,6 +19,7 @@ from letsql.backends.postgres import (
     Backend as PGBackend,
 )
 
+
 try:
     from sqlglot.expressions import Alter
 except ImportError:

--- a/python/letsql/common/utils/snowflake_utils.py
+++ b/python/letsql/common/utils/snowflake_utils.py
@@ -1,9 +1,9 @@
 import os
 
-import letsql as ls
 import pandas as pd
 import snowflake.connector
 
+import letsql as ls
 import letsql.backends.snowflake.hotfix  # noqa: F401
 
 

--- a/python/letsql/config.py
+++ b/python/letsql/config.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import Union, Optional, Any
+from typing import Any, Optional, Union
 
 import ibis
 from ibis.config import Config

--- a/python/letsql/expr/api.py
+++ b/python/letsql/expr/api.py
@@ -5,16 +5,16 @@ from __future__ import annotations
 import datetime
 import functools
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Union, overload, Iterable, Mapping
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, Union, overload
 
-import pyarrow as pa
-import pyarrow.dataset as ds
 import ibis
 import ibis.expr.builders as bl
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
+import pyarrow as pa
+import pyarrow.dataset as ds
 from ibis import api
 from ibis.backends.sql.dialects import DataFusion
 from ibis.common.deferred import Deferred, _, deferrable
@@ -38,19 +38,20 @@ from ibis.expr.types import (
 from letsql.common.utils.caching_utils import find_backend
 from letsql.common.utils.defer_utils import rbr_wrapper
 from letsql.common.utils.graph_utils import replace_fix
+from letsql.expr.ml import train_test_splits
 from letsql.expr.relations import (
     CachedNode,
     register_and_transform_remote_tables,
 )
-from letsql.expr.ml import train_test_splits
+
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
     from pathlib import Path
 
-    from ibis.expr.schema import SchemaLike
-    import pyarrow as pa
     import pandas as pd
+    import pyarrow as pa
+    from ibis.expr.schema import SchemaLike
 
 __all__ = (
     "Column",
@@ -1693,8 +1694,8 @@ def to_parquet(
     **kwargs: Any,
 ):
     import pyarrow  # noqa: ICN001, F401
-    import pyarrow_hotfix  # noqa: F401
     import pyarrow.parquet as pq
+    import pyarrow_hotfix  # noqa: F401
 
     with to_pyarrow_batches(expr, params=params) as batch_reader:
         with pq.ParquetWriter(path, batch_reader.schema, **kwargs) as writer:

--- a/python/letsql/expr/ml.py
+++ b/python/letsql/expr/ml.py
@@ -1,5 +1,5 @@
 from random import Random
-from typing import Tuple, Iterable, List, Iterator
+from typing import Iterable, Iterator, List, Tuple
 
 # TODO: How should we / should we enforce letsql table ?
 import ibis.expr.types as ir

--- a/python/letsql/expr/relations.py
+++ b/python/letsql/expr/relations.py
@@ -4,11 +4,11 @@ from typing import Any
 
 import ibis
 import pyarrow as pa
-from ibis import Schema, Expr
+from ibis import Expr, Schema
 from ibis.common.collections import FrozenDict
 from ibis.common.graph import Graph
 from ibis.expr import operations as ops
-from ibis.expr.operations import Relation, Node
+from ibis.expr.operations import Node, Relation
 
 from letsql.common.utils.graph_utils import replace_fix
 

--- a/python/letsql/expr/udf.py
+++ b/python/letsql/expr/udf.py
@@ -1,4 +1,5 @@
 import functools
+from typing import Any
 
 import ibis.expr.rules as rlz
 import ibis.expr.types as ir
@@ -6,8 +7,7 @@ import toolz
 from ibis.common.annotations import Argument
 from ibis.common.collections import FrozenDict
 from ibis.expr.operations import Namespace
-from ibis.expr.operations.udf import _UDF, AggUDF, _wrap, InputType, _make_udf_name
-from typing import Any
+from ibis.expr.operations.udf import _UDF, AggUDF, InputType, _make_udf_name, _wrap
 
 
 class agg(_UDF):

--- a/python/letsql/internal.py
+++ b/python/letsql/internal.py
@@ -6,6 +6,7 @@ import pyarrow as pa
 from letsql._internal import (
     AggregateUDF,
     ContextProvider,
+    DataFrame,
     LogicalPlan,
     LogicalPlanBuilder,
     OptimizerContext,
@@ -14,11 +15,11 @@ from letsql._internal import (
     SessionConfig,  # noqa: F401
     SessionContext,  # noqa: F401
     SessionState,  # noqa: F401
-    TableProvider,
     Table,
-    DataFrame,
+    TableProvider,
     WindowUDF,
 )
+
 
 __all__ = [
     "SessionContext",

--- a/python/letsql/optimizer/tests/test_optimize.py
+++ b/python/letsql/optimizer/tests/test_optimize.py
@@ -2,8 +2,8 @@ import pyarrow as pa
 import pytest
 from pandas.testing import assert_frame_equal, assert_series_equal
 
-from letsql.optimizer import optimize_ibis, optimize_sql
 import letsql as ls
+from letsql.optimizer import optimize_ibis, optimize_sql
 
 
 @pytest.fixture(scope="session")

--- a/python/letsql/tests/test_array.py
+++ b/python/letsql/tests/test_array.py
@@ -7,7 +7,7 @@ import pytest
 from pytest import param
 
 import letsql as ls
-from letsql.tests.util import assert_series_equal, assert_frame_equal
+from letsql.tests.util import assert_frame_equal, assert_series_equal
 
 
 @pytest.fixture(scope="module")

--- a/python/letsql/tests/test_client.py
+++ b/python/letsql/tests/test_client.py
@@ -13,6 +13,7 @@ from pytest import param
 import letsql as ls
 from letsql.tests.util import assert_frame_equal
 
+
 if TYPE_CHECKING:
     pass
 

--- a/python/letsql/tests/test_examples.py
+++ b/python/letsql/tests/test_examples.py
@@ -1,6 +1,6 @@
 import pathlib
-
 import runpy
+
 import pytest
 from pytest import param
 

--- a/python/letsql/tests/test_into_backend.py
+++ b/python/letsql/tests/test_into_backend.py
@@ -5,8 +5,9 @@ import pytest
 from ibis import _
 
 import letsql as ls
-from letsql.common.caching import SourceStorage, ParquetCacheStorage
+from letsql.common.caching import ParquetCacheStorage, SourceStorage
 from letsql.expr.relations import into_backend, register_and_transform_remote_tables
+
 
 expected_tables = (
     "array_types",

--- a/python/letsql/tests/test_ml.py
+++ b/python/letsql/tests/test_ml.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from ibis import memtable
+import pandas as pd
 import pytest
+from ibis import memtable
+
 import letsql as ls
 from letsql.expr.ml import _calculate_bounds
-import pandas as pd
 from letsql.tests.util import assert_frame_equal
 
 

--- a/python/letsql/tests/test_param.py
+++ b/python/letsql/tests/test_param.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import letsql as ls
 import ibis.expr.datatypes as dt
 import pytest
 
-from letsql.tests.util import default_series_rename, assert_series_equal
+import letsql as ls
+from letsql.tests.util import assert_series_equal, default_series_rename
 
 
 @pytest.mark.parametrize(

--- a/python/letsql/tests/test_select.py
+++ b/python/letsql/tests/test_select.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from letsql.tests.util import assert_frame_equal
-
 import letsql as ls
+from letsql.tests.util import assert_frame_equal
 
 
 def test_where_multiple_conditions(alltypes, df):

--- a/python/letsql/tests/test_struct.py
+++ b/python/letsql/tests/test_struct.py
@@ -9,7 +9,7 @@ import pytest
 from pytest import param
 
 import letsql as ls
-from letsql.tests.util import assert_series_equal, assert_frame_equal
+from letsql.tests.util import assert_frame_equal, assert_series_equal
 
 
 @pytest.mark.parametrize(

--- a/python/letsql/tests/test_udf.py
+++ b/python/letsql/tests/test_udf.py
@@ -10,6 +10,7 @@ from ibis import udf
 
 import letsql as ls
 
+
 pc = pytest.importorskip("pyarrow.compute")
 
 

--- a/python/letsql/tests/util.py
+++ b/python/letsql/tests/util.py
@@ -3,6 +3,7 @@ from typing import Any
 import pandas as pd
 import pandas.testing as tm
 
+
 reduction_tolerance = 1e-7
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1340,7 +1340,6 @@ wheels = [
 
 [[package]]
 name = "letsql"
-version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "adbc-driver-postgresql", marker = "python_full_version < '4.0'" },


### PR DESCRIPTION
The `pyproject.toml` contains the following configuration:

for import sorting:
```toml 
select = ["I"]  
```
ignore the rule for the main `__init__.py`, sorting causes circular import issues 

```toml
[tool.ruff.lint.per-file-ignores]
"python/letsql/__init__.py" = ["I001"]
```
ensure that letsql is treated as a first-party package, also what section order to follow and the lines after an import

```toml
[tool.ruff.lint.isort]
known-first-party = ["letsql"]
section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
lines-after-imports = 2
```

The values for the configuration can be consulted on:

https://docs.astral.sh/ruff/rules/#isort-i
https://docs.astral.sh/ruff/settings/#lintisort
https://docs.astral.sh/ruff/settings/#lint_per-file-ignores
https://stackoverflow.com/q/77680073/

The `ci-lint.yml` file was updated to match the one in the `pre-commit-config.yaml`