### PR TITLE
feat: add ordering arg to register_record_batch_reader

### DIFF
--- a/python/letsql/backends/let/tests/test_client.py
+++ b/python/letsql/backends/let/tests/test_client.py
@@ -103,4 +103,8 @@ def test_register_record_batch_reader_sorted(batting_df, keys):
     expr = t.group_by("yearID").agg(max_tiny=t["stint"].max())
 
     physical_plan = ls.get_plans(expr)["physical_plan"]
-    assert not keys or "ordering_mode=Sorted" in physical_plan
+    ordering_string = "ordering_mode=Sorted"
+    if keys:
+        assert ordering_string in physical_plan
+    else:
+        assert ordering_string not in physical_plan

--- a/python/letsql/backends/let/tests/test_client.py
+++ b/python/letsql/backends/let/tests/test_client.py
@@ -1,5 +1,7 @@
 import ibis
 import pyarrow as pa
+import pytest
+from pytest import param
 
 import letsql as ls
 from letsql.tests.util import (
@@ -75,3 +77,30 @@ def test_register_table_with_uppercase_multiple_times(ls_con):
     assert uppercase_table_name in ls_con.list_tables()
     assert ls.execute(t) is not None
     assert t.schema() == expected_schema
+
+
+@pytest.mark.parametrize(
+    "keys",
+    [
+        param(tuple(), id="empty"),
+        param((ls.asc("yearID"),), id="one-column"),
+        param((ls.asc("yearID"), ls.desc("stint")), id="two-columns"),
+    ],
+)
+def test_register_record_batch_reader_sorted(batting_df, keys):
+    con = ls.connect()
+    t = con.register(batting_df, "batting")
+
+    if keys:
+        t = t.order_by(*keys)
+
+    record_batch_reader = t.select("yearID", "stint").to_pyarrow_batches()
+    t = con.register(
+        record_batch_reader,
+        "t2",
+        ordering=[key.resolve(t) for key in keys],
+    )
+    expr = t.group_by("yearID").agg(max_tiny=t["stint"].max())
+
+    physical_plan = ls.get_plans(expr)["physical_plan"]
+    assert not keys or "ordering_mode=Sorted" in physical_plan

--- a/python/letsql/common/utils/dask_normalize_expr.py
+++ b/python/letsql/common/utils/dask_normalize_expr.py
@@ -74,7 +74,7 @@ def normalize_datafusion_databasetable(dt):
         )
     elif ep_str.startswith("MemoryExec:"):
         return normalize_memory_databasetable(dt)
-    elif ep_str.startswith("CustomExec"):
+    elif ep_str.startswith("PyRecordBatchProviderExec"):
         return dask.tokenize._normalize_seq_func((dt.schema.to_pandas(), dt.name))
     else:
         raise ValueError

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -30,6 +30,7 @@ use datafusion_expr::{
     utils::exprlist_to_fields,
     Between, BinaryExpr, Case, Cast, Expr, Like, LogicalPlan, Operator, TryCast,
 };
+use sort_expr::PySortExpr;
 
 use crate::common::data_type::{DataTypeMap, RexType};
 use crate::errors::{py_datafusion_err, py_runtime_err, py_type_err, DataFusionError};
@@ -247,7 +248,7 @@ impl PyExpr {
 
     /// Create a sort PyExpr from an existing PyExpr.
     #[pyo3(signature = (ascending=true, nulls_first=true))]
-    pub fn sort(&self, ascending: bool, nulls_first: bool) -> PyOrdered {
+    pub fn sort(&self, ascending: bool, nulls_first: bool) -> PySortExpr {
         self.expr.clone().sort(ascending, nulls_first).into()
     }
 
@@ -717,6 +718,7 @@ pub(crate) fn init_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<window::PyWindowFrame>()?;
     m.add_class::<window::PyWindowFrameBound>()?;
     m.add_class::<PyOrdered>()?;
+    m.add_class::<PySortExpr>()?;
     m.add_class::<PyWildcard>()?;
     Ok(())
 }

--- a/src/expr/sort_expr.rs
+++ b/src/expr/sort_expr.rs
@@ -23,7 +23,7 @@ use std::fmt::{self, Display, Formatter};
 #[pyclass(name = "SortExpr", module = "datafusion.expr", subclass)]
 #[derive(Clone)]
 pub struct PySortExpr {
-    sort: SortExpr,
+    pub sort: SortExpr,
 }
 
 impl From<PySortExpr> for SortExpr {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use arrow::array::ArrayRef;
 use arrow::datatypes::SchemaRef;
-use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion::physical_expr::{EquivalenceProperties, LexOrdering, Partitioning};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::PlanProperties;
 use datafusion_common::{Result, ScalarValue};
@@ -55,6 +55,20 @@ pub(crate) fn parse_volatility(value: &str) -> Result<Volatility, DataFusionErro
 
 pub fn compute_properties(schema: SchemaRef) -> PlanProperties {
     let eq_properties = EquivalenceProperties::new(schema);
+
+    PlanProperties::new(
+        eq_properties,
+        Partitioning::UnknownPartitioning(1),
+        EmissionType::Incremental,
+        Boundedness::Bounded,
+    )
+}
+
+pub fn compute_properties_with_orderings(
+    schema: SchemaRef,
+    orderings: &[LexOrdering],
+) -> PlanProperties {
+    let eq_properties = EquivalenceProperties::new_with_orderings(schema, orderings);
 
     PlanProperties::new(
         eq_properties,


### PR DESCRIPTION
This enables parent plans in DataFusion to take advantage of the
sortedness of the RecordBatchReader.

closes #470 