### PR TITLE
chore: extend ruff select rules instead of overwriting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,8 +117,7 @@ python-source = "python"
 features = ["pyo3/extension-module"]
 
 [tool.ruff.lint]
-select = ["I"]
-extend-select = ["ICN"]
+extend-select = ["I", "ICN"]
 
 [tool.ruff.lint.per-file-ignores]
 "python/letsql/__init__.py" = ["I001"]


### PR DESCRIPTION
By setting `select`, we overwrite **ruff** default rules:

```toml
["E4", "E7", "E9", "F"]
```

Instead, we should use `extend-select`  to preserve default rules:

```
[tool.ruff.lint]
extend-select = ["I", "ICN"]
```