### PR TITLE
fix/nix-editable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,10 @@
             drv = letsql-312.virtualenv;
             name = "ipython";
           };
+          ipython-310-v0-1-12 = drvToApp {
+            drv = letsql-310.virtualenv-pypi;
+            name = "ipython";
+          };
           default = self.apps.${system}.ipython-310;
         };
         lib = {
@@ -119,6 +123,7 @@
           virtualenv-editable-311 = letsql-311.editableShell;
           virtualenv-312 = letsql-312.shell;
           virtualenv-editable-312 = letsql-312.editableShell;
+          virtualenv-pypi-310 = letsql-310.pypiShell;
           default = self.devShells.${system}.virtualenv-310;
         };
       }

--- a/nix/pyproject.build-system.diff
+++ b/nix/pyproject.build-system.diff
@@ -1,0 +1,16 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 1892e91..fe9f693 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,6 +1,9 @@
+ [build-system]
+-requires = ["maturin>=1.2,<2.0"]
+-build-backend = "maturin"
++requires = ["setuptools", "setuptools-scm"]
++build-backend = "setuptools.build_meta"
++
++[tool.setuptools]
++package-dir = {"" = "python"}
+ 
+ [project]
+ name = "letsql"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ authors = [
     { name = "Hussain Sultan", email = "hussain@letsql.com" },
 ]
 maintainers = [
-    { email = "Dan Lovell <dan@letsql.com>" },
-    { email = "Daniel Mesejo <mesejo@letsql.com>" },
+    { name = "Dan Lovell", email = "dan@letsql.com" },
+    { name = "Daniel Mesejo", email ="mesejo@letsql.com" },
 ]
 description = "Data processing library built on top of Ibis and DataFusion to write multi-engine data workflows."
 readme = "README.md"


### PR DESCRIPTION
nix dev env no longer builds any rust/maturin at all
also exposes an app that uses pypi for letsql for a no rust/maturin build nix run command: `nix run --refresh github:letsql/letsql/fix/nix-editable#ipython-310-v0-1-12`