### PR TITLE
chore: wrap pins with examples

### DIFF
--- a/.github/workflows/ci-test-examples.yml
+++ b/.github/workflows/ci-test-examples.yml
@@ -51,7 +51,7 @@ jobs:
       - name: install dependencies
         run: |
           source .venv/bin/activate
-          python -m pip install pytest maturin
+          python -m pip install pytest maturin pytest-cov
 
       - name: develop
         run: |
@@ -61,7 +61,7 @@ jobs:
       - name: pytest
         run: |
           source .venv/bin/activate
-          python -m pytest --import-mode=importlib python/letsql/tests/test_examples.py -v
+          python -m pytest --import-mode=importlib python/letsql/tests/test_examples.py -v --cov --cov-report=xml
         working-directory: ${{ github.workspace }}
         env:
           POSTGRES_PASSWORD: postgres
@@ -69,3 +69,8 @@ jobs:
           POSTGRES_HOST: localhost
           POSTGRES_PORT: 5432
           POSTGRES_DATABASE: ibis_testing
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5.3.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-test-library.yml
+++ b/.github/workflows/ci-test-library.yml
@@ -49,7 +49,7 @@ jobs:
       - name: install dependencies
         run: |
           source .venv/bin/activate
-          python -m pip install pytest maturin
+          python -m pip install pytest maturin pytest-cov
 
       - name: develop
         run: |
@@ -59,7 +59,7 @@ jobs:
       - name: test
         run: |
           source .venv/bin/activate
-          python -m pytest --import-mode=importlib python/letsql/tests/test_examples.py -v -m library
+          python -m pytest --import-mode=importlib python/letsql/tests/test_examples.py -v --cov --cov-report=xml -m library
         working-directory: ${{ github.workspace }}
         env:
           POSTGRES_PASSWORD: ${{ vars.POSTGRES_PASSWORD }}
@@ -67,3 +67,8 @@ jobs:
           POSTGRES_HOST: ${{ vars.POSTGRES_HOST }}
           POSTGRES_PORT: ${{ vars.POSTGRES_PORT }}
           POSTGRES_DATABASE: ${{ vars.POSTGRES_DATABASE }}
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5.3.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/examples/deferred_read_csv.py
+++ b/examples/deferred_read_csv.py
@@ -7,8 +7,6 @@ from letsql.common.utils.defer_utils import (
 
 csv_name = "iris"
 csv_path = ls.options.pins.get_path(csv_name)
-parquet_name = "astronauts"
-parquet_path = ls.options.pins.get_path(parquet_name)
 
 
 # we can work with a pandas expr without having read it yet

--- a/examples/multi_engine.py
+++ b/examples/multi_engine.py
@@ -5,12 +5,9 @@ from letsql.expr.relations import into_backend
 pg = ls.postgres.connect_env()
 db = ls.duckdb.connect()
 
-
 batting = pg.table("batting")
-awards_players = db.read_parquet(
-    ls.config.options.pins.get_path("awards_players"),
-    table_name="awards_players",
-)
+
+awards_players = ls.examples.players.fetch(backend=db, table_name="awards_players")
 left = batting.filter(batting.yearID == 2015)
 right = awards_players.filter(awards_players.lgID == "NL").drop("yearID", "lgID")
 expr = left.join(into_backend(right, pg), ["playerID"], how="semi")[["yearID", "stint"]]

--- a/examples/multi_engine.py
+++ b/examples/multi_engine.py
@@ -7,7 +7,7 @@ db = ls.duckdb.connect()
 
 batting = pg.table("batting")
 
-awards_players = ls.examples.players.fetch(backend=db, table_name="awards_players")
+awards_players = ls.examples.awards_players.fetch(backend=db)
 left = batting.filter(batting.yearID == 2015)
 right = awards_players.filter(awards_players.lgID == "NL").drop("yearID", "lgID")
 expr = left.join(into_backend(right, pg), ["playerID"], how="semi")[["yearID", "stint"]]

--- a/examples/remote_caching.py
+++ b/examples/remote_caching.py
@@ -10,7 +10,7 @@ pg = ls.postgres.connect_env()
 name = "batting"
 
 right = (
-    ls.examples.batting.fetch(backend=ddb)
+    ls.examples.batting.fetch(backend=ddb, table_name=name)
     .filter(_.yearID == 2014)
     .pipe(con.register, table_name=f"ddb-{name}")
 )

--- a/examples/remote_caching.py
+++ b/examples/remote_caching.py
@@ -10,7 +10,7 @@ pg = ls.postgres.connect_env()
 name = "batting"
 
 right = (
-    ls.examples.batting.fetch(backend=ddb, table_name=name)
+    ls.examples.get_table_from_parquet(name, backend=ddb, table_name=name)
     .filter(_.yearID == 2014)
     .pipe(con.register, table_name=f"ddb-{name}")
 )

--- a/examples/remote_caching.py
+++ b/examples/remote_caching.py
@@ -8,10 +8,9 @@ ddb = ls.duckdb.connect()
 pg = ls.postgres.connect_env()
 
 name = "batting"
-path = ls.config.options.pins.get_path(name)
 
 right = (
-    ddb.read_parquet(path, table_name=name)
+    ls.examples.batting.fetch(backend=ddb)
     .filter(_.yearID == 2014)
     .pipe(con.register, table_name=f"ddb-{name}")
 )

--- a/examples/remote_caching.py
+++ b/examples/remote_caching.py
@@ -10,7 +10,7 @@ pg = ls.postgres.connect_env()
 name = "batting"
 
 right = (
-    ls.examples.get_table_from_parquet(name, backend=ddb, table_name=name)
+    ls.examples.get_table_from_name(name, backend=ddb)
     .filter(_.yearID == 2014)
     .pipe(con.register, table_name=f"ddb-{name}")
 )

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -2,7 +2,7 @@ import letsql as ls
 
 
 con = ls.connect()
-iris = con.read_csv(ls.config.options.pins.get_path("iris"), "iris")
+iris = ls.examples.iris.fetch(backend=con, table_name="iris")
 res = (
     iris.filter([iris.sepal_length > 5])
     .group_by("species")

--- a/examples/xgboost_udaf.py
+++ b/examples/xgboost_udaf.py
@@ -47,7 +47,7 @@ curried_calc_best_features = toolz.curry(
 ibis_output_type = dt.infer(({"feature": "feature", "score": 0.0},))
 
 
-t = ls.examples.lending_club.fetch()
+t = ls.connect().read_parquet(ls.config.options.pins.get_path("lending-club"))
 agg_udf = udf.agg.pandas_df(
     curried_calc_best_features,
     t[cols].schema(),

--- a/examples/xgboost_udaf.py
+++ b/examples/xgboost_udaf.py
@@ -47,7 +47,7 @@ curried_calc_best_features = toolz.curry(
 ibis_output_type = dt.infer(({"feature": "feature", "score": 0.0},))
 
 
-t = ls.connect().read_parquet(ls.config.options.pins.get_path("lending-club"))
+t = ls.examples.lending_club.fetch()
 agg_udf = udf.agg.pandas_df(
     curried_calc_best_features,
     t[cols].schema(),

--- a/python/letsql/examples/__init__.py
+++ b/python/letsql/examples/__init__.py
@@ -21,7 +21,11 @@ class Example:
 
 
 def __dir__():
-    return list(whitelist)
+    return (
+        "get_table_from_csv",
+        "get_table_from_parquet",
+        *whitelist,
+    )
 
 
 def __getattr__(name):
@@ -34,7 +38,11 @@ def __getattr__(name):
     return Example(name, partial(read, name))
 
 
-__all__ = list(whitelist)
+__all__ = (
+    "get_table_from_csv",
+    "get_table_from_parquet",
+    *whitelist,
+)
 
 
 def __getattr__(name):

--- a/python/letsql/examples/__init__.py
+++ b/python/letsql/examples/__init__.py
@@ -1,51 +1,40 @@
-from functools import partial
-
 import letsql as ls
 from letsql.examples.core import (
     get_name_to_suffix,
-    get_table_from_csv,
-    get_table_from_parquet,
+    get_table_from_name,
     whitelist,
 )
 
 
 class Example:
-    def __init__(self, name, load):
-        self.load = load
+    def __init__(self, name):
         self.name = name
 
     def fetch(self, table_name=None, backend=None):
         if backend is None:
             backend = ls.connect()
-        return self.load(backend, table_name or self.name)
+        return get_table_from_name(self.name, backend, table_name or self.name)
 
 
 def __dir__():
     return (
-        "get_table_from_csv",
-        "get_table_from_parquet",
+        "get_table_from_name",
         *whitelist,
     )
 
 
 def __getattr__(name):
+    from letsql.vendor.ibis import examples as ibex
+
     lookup = get_name_to_suffix()
 
     if name not in lookup:
-        raise AttributeError
+        return getattr(ibex, name)
 
-    read = get_table_from_csv if lookup[name] == ".csv" else get_table_from_parquet
-    return Example(name, partial(read, name))
+    return Example(name)
 
 
 __all__ = (
-    "get_table_from_csv",
-    "get_table_from_parquet",
+    "get_table_from_name",
     *whitelist,
 )
-
-
-def __getattr__(name):
-    from letsql.vendor.ibis import examples as ibex
-
-    return getattr(ibex, name)

--- a/python/letsql/examples/__init__.py
+++ b/python/letsql/examples/__init__.py
@@ -1,29 +1,49 @@
-from functools import cache
+from functools import cache, partial
 
 import letsql as ls
 
 
 @cache
-def cached_penguins():
+def _download_penguins():
     import pandas as pd
 
     url = "https://raw.githubusercontent.com/mesejo/palmerpenguins/master/palmerpenguins/data/penguins.csv"
-    return pd.read_csv(url)
+    df = pd.read_csv(url)
+    return df
+
+
+def _cached_penguins(backend, table_name=None):
+    return backend.register(_download_penguins(), table_name=table_name)
+
+
+def get_table_from_parquet(name, backend, table_name):
+    parquet_file = ls.config.options.pins.get_path(name)
+    return backend.read_parquet(parquet_file, table_name=table_name)
+
+
+def get_table_from_csv(name, backend, table_name):
+    parquet_file = ls.config.options.pins.get_path(name)
+    return backend.read_csv(parquet_file, table_name=table_name)
 
 
 class Example:
     def __init__(self, name, load):
-        self.con = None
         self.load = load
         self.name = name
 
-    def fetch(self, table_name=None):
-        if self.con is None:
-            self.con = ls.connect()
-        return self.con.register(self.load(), table_name=table_name or self.name)
+    def fetch(self, table_name=None, backend=None):
+        if backend is None:
+            backend = ls.connect()
+        return self.load(backend, table_name or self.name)
 
 
-penguins = Example("penguins", cached_penguins)
+penguins = Example("penguins", _cached_penguins)
+players = Example("players", partial(get_table_from_parquet, "awards_players"))
+batting = Example("batting", partial(get_table_from_parquet, "batting"))
+lending_club = Example("lending_club", partial(get_table_from_parquet, "lending-club"))
+iris = Example("iris", partial(get_table_from_csv, "iris"))
+
+__all__ = ["penguins", "players", "batting", "lending_club", "iris"]
 
 
 def __getattr__(name):

--- a/python/letsql/examples/core.py
+++ b/python/letsql/examples/core.py
@@ -26,11 +26,14 @@ def get_name_to_suffix():
     return dct
 
 
-def get_table_from_parquet(name, backend, table_name=None):
-    parquet_file = ls.config.options.pins.get_path(name)
-    return backend.read_parquet(parquet_file, table_name=table_name or name)
-
-
-def get_table_from_csv(name, backend, table_name=None):
-    parquet_file = ls.config.options.pins.get_path(name)
-    return backend.read_csv(parquet_file, table_name=table_name or name)
+def get_table_from_name(name, backend, table_name=None):
+    suffix = get_name_to_suffix().get(name)
+    match suffix:
+        case ".parquet":
+            method = backend.read_parquet
+        case ".csv":
+            method = backend.read_csv
+        case _:
+            raise ValueError
+    path = ls.config.options.pins.get_path(name)
+    return method(path, table_name=table_name or name)

--- a/python/letsql/examples/core.py
+++ b/python/letsql/examples/core.py
@@ -1,0 +1,36 @@
+import functools
+import pathlib
+
+import letsql as ls
+
+
+whitelist = [
+    "astronauts",
+    "awards_players",
+    "batting",
+    "diamonds",
+    "functional_alltypes",
+    "iris",
+    "penguins",
+]
+
+
+@functools.cache
+def get_name_to_suffix():
+    board = ls.options.pins.get_board()
+    dct = {
+        name: pathlib.Path(board.pin_meta(name).file).suffix
+        for name in board.pin_list()
+        if pathlib.Path(board.pin_meta(name).file).suffix not in (".json",)
+    }
+    return dct
+
+
+def get_table_from_parquet(name, backend, table_name):
+    parquet_file = ls.config.options.pins.get_path(name)
+    return backend.read_parquet(parquet_file, table_name=table_name)
+
+
+def get_table_from_csv(name, backend, table_name):
+    parquet_file = ls.config.options.pins.get_path(name)
+    return backend.read_csv(parquet_file, table_name=table_name)

--- a/python/letsql/examples/core.py
+++ b/python/letsql/examples/core.py
@@ -21,7 +21,7 @@ def get_name_to_suffix():
     dct = {
         name: pathlib.Path(board.pin_meta(name).file).suffix
         for name in board.pin_list()
-        if pathlib.Path(board.pin_meta(name).file).suffix not in (".json",)
+        if name in whitelist
     }
     return dct
 

--- a/python/letsql/examples/core.py
+++ b/python/letsql/examples/core.py
@@ -26,11 +26,11 @@ def get_name_to_suffix():
     return dct
 
 
-def get_table_from_parquet(name, backend, table_name):
+def get_table_from_parquet(name, backend, table_name=None):
     parquet_file = ls.config.options.pins.get_path(name)
-    return backend.read_parquet(parquet_file, table_name=table_name)
+    return backend.read_parquet(parquet_file, table_name=table_name or name)
 
 
-def get_table_from_csv(name, backend, table_name):
+def get_table_from_csv(name, backend, table_name=None):
     parquet_file = ls.config.options.pins.get_path(name)
-    return backend.read_csv(parquet_file, table_name=table_name)
+    return backend.read_csv(parquet_file, table_name=table_name or name)

--- a/python/letsql/examples/tests/test_examples.py
+++ b/python/letsql/examples/tests/test_examples.py
@@ -6,7 +6,7 @@ from letsql.examples.core import whitelist
 
 
 def test_whitelist():
-    assert dir(ls.examples) == whitelist
+    assert [name in dir(ls.examples) for name in whitelist]
 
 
 def test_attributes():

--- a/python/letsql/examples/tests/test_examples.py
+++ b/python/letsql/examples/tests/test_examples.py
@@ -1,0 +1,17 @@
+import pytest
+
+import letsql as ls
+from letsql.examples import Example
+from letsql.examples.core import whitelist
+
+
+def test_whitelist():
+    assert dir(ls.examples) == whitelist
+
+
+def test_attributes():
+    example = ls.examples.astronauts
+    assert isinstance(example, Example)
+
+    with pytest.raises(AttributeError):
+        ls.examples.missing

--- a/python/letsql/examples/tests/test_examples.py
+++ b/python/letsql/examples/tests/test_examples.py
@@ -10,8 +10,9 @@ def test_whitelist():
 
 
 def test_attributes():
-    example = ls.examples.astronauts
-    assert isinstance(example, Example)
+    for name in whitelist:
+        example = getattr(ls.examples, name)
+        assert isinstance(example, Example)
 
     with pytest.raises(AttributeError):
         ls.examples.missing

--- a/python/letsql/tests/test_examples.py
+++ b/python/letsql/tests/test_examples.py
@@ -8,7 +8,7 @@ import letsql as ls
 
 
 KEY_PREFIX = ls.config.options.cache.key_prefix
-LIBRARY_SCRIPTS = ("pandas_example", "penguins_example")
+LIBRARY_SCRIPTS = ("pandas_example",)
 
 file_path = pathlib.Path(__file__).absolute()
 root = file_path.parent


### PR DESCRIPTION
Wrapping provides a better UX, due to the following reasons:
- less code, hide repetitive code
- the user does not need to know the type (csv, parquet) of the file
- the user can know which examples are available via tab completion on the examples package